### PR TITLE
feat: exit CLI non-zero on scan failure

### DIFF
--- a/cmd/kubesec/main.go
+++ b/cmd/kubesec/main.go
@@ -39,6 +39,12 @@ func main() {
 	rootCmd.SetArgs(os.Args[1:])
 	if err := rootCmd.Execute(); err != nil {
 		e := err.Error()
+
+		switch err.(type) {
+		case *ScanFailedValidationError:
+			os.Exit(2)
+		}
+
 		fmt.Println(strings.ToUpper(e[:1]) + e[1:])
 		os.Exit(1)
 	}

--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -11,6 +11,13 @@ import (
 	"path/filepath"
 )
 
+type ScanFailedValidationError struct {
+}
+
+func (e *ScanFailedValidationError) Error() string {
+	return fmt.Sprintf("Kubesec scan failed")
+}
+
 func init() {
 	rootCmd.AddCommand(scanCmd)
 }
@@ -52,6 +59,12 @@ var scanCmd = &cobra.Command{
 		}
 
 		fmt.Println(server.PrettyJSON(res))
-		return nil
+		if report.Score > 0 {
+			return nil
+		}
+
+		rootCmd.SilenceErrors = true
+		rootCmd.SilenceUsage = true
+		return &ScanFailedValidationError{}
 	},
 }

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -27,7 +27,7 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 
 	hostPIDRule := Rule{
 		Predicate: rules.HostPID,
-		Selector:  ".spec .hostPID == true)",
+		Selector:  ".spec .hostPID == true",
 		Reason:    "Sharing the host's PID namespace allows visibility of processes on the host, potentially leaking information such as environment variables and configuration",
 		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
 		Points:    -9,
@@ -36,7 +36,7 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 
 	hostIPCRule := Rule{
 		Predicate: rules.HostIPC,
-		Selector:  ".spec .hostIPC == true)",
+		Selector:  ".spec .hostIPC == true",
 		Reason:    "Sharing the host's IPC namespace allows container processes to communicate with processes on the host",
 		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
 		Points:    -9,


### PR DESCRIPTION
- local tests suggest this doesn't affect HTTP mode
- this enables use of the existing acceptance test suite