### PR TITLE
feat: add seccomp any for named pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-go-fmt: ## golang fmt check
 
 .PHONY: test-go
 test-go: ## golang unit tests
-	go test -race $$(go list ./... | grep -v '/vendor/')
+	go test -race $$(go list ./... | grep -v '/vendor/') -run "$${RUN:-.*}"
 
 test-go-verbose: ## golang unit tests
 	go test -race -v $$(go list ./... | grep -v '/vendor/')

--- a/pkg/rules/seccompAny.go
+++ b/pkg/rules/seccompAny.go
@@ -4,21 +4,37 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/thedevsaddam/gojsonq"
+	"regexp"
 	"strings"
 )
 
-// TODO(ajm) this should be checking for the name of the pod, not `pod`, so needs wildcard matching
+// TODO(ajm): tighten these matches, they could be "[seccomp..." or " seccomp...", and "unconfined]" or "unconfined "
+// TODO(ajm): space delimiting matches is insufficient as this could be set to `unconfined blah`
 func SeccompAny(json []byte) int {
 	containers := 0
+	startWordBoundaryRegex := "[\\[ ]"
+	endWordBoundaryRegex := "[\\] ]"
 
 	capDrop := gojsonq.New().Reader(bytes.NewReader(json)).
 		From("metadata.annotations").Get()
 
-	if capDrop != nil && strings.Contains(fmt.Sprintf("%v", capDrop), "seccomp.security.alpha.kubernetes.io/pod:") {
-		// TODO(ajm): tighten these matches, they could be "[seccomp..." or " seccomp...", and "unconfined]" or "unconfined "
-		// TODO(ajm): space delimiting matches is insufficient as this could be set to `unconfined blah`
-		if !strings.Contains(fmt.Sprintf("%v", capDrop), "seccomp.security.alpha.kubernetes.io/pod:unconfined") {
+	capDropString := fmt.Sprintf("%v", capDrop)
+
+	if capDrop != nil && strings.Contains(capDropString, "seccomp.security.alpha.kubernetes.io/pod:") {
+		if !strings.Contains(capDropString, "seccomp.security.alpha.kubernetes.io/pod:unconfined") {
 			containers++
+		}
+	} else if capDrop != nil {
+
+		keyNameRegex := "seccomp\\.security\\.alpha\\.kubernetes\\.io/[a-zA-Z-.]+"
+		// TODO(ajm) match end of string in regex
+		isNamedPodMatch, _ := regexp.MatchString(startWordBoundaryRegex+keyNameRegex+":", capDropString)
+
+		if isNamedPodMatch == true {
+			isUnconfinedNamedPodMatch, _ := regexp.MatchString(startWordBoundaryRegex+keyNameRegex+":unconfined"+endWordBoundaryRegex, capDropString)
+			if !isUnconfinedNamedPodMatch {
+				containers++
+			}
 		}
 	}
 

--- a/pkg/rules/seccompAny_test.go
+++ b/pkg/rules/seccompAny_test.go
@@ -57,7 +57,7 @@ spec:
 	}
 }
 
-func Test_SeccompAnyMissing_Pod(t *testing.T) {
+func Test_SeccompAny_No_Seccomp(t *testing.T) {
 	var data = `
 ---
 apiVersion: v1
@@ -72,6 +72,106 @@ spec:
    securityContext:
      capabilities:
  - name: c3
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := SeccompAny(json)
+	if containers != 0 {
+		t.Errorf("Got %v containers wanted %v", containers, 0)
+	}
+}
+
+func Test_SeccompAny_Named_Pod(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/somePodName: runtime/default
+spec:
+  containers:
+    - name: somePodName
+      image: sotrustworthy:latest
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := SeccompAny(json)
+	if containers != 1 {
+		t.Errorf("Got %v containers wanted %v", containers, 1)
+	}
+}
+
+func Test_SeccompAny_Named_Pod_Special_Chars(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+ annotations:
+   seccomp.security.alpha.kubernetes.io/my-Named.Pod: runtime/default
+spec:
+ containers:
+   - name: trustworthy-container
+     image: sotrustworthy:latest
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := SeccompAny(json)
+	if containers != 1 {
+		t.Errorf("Got %v containers wanted %v", containers, 1)
+	}
+}
+
+func Test_SeccompAny_Named_Pod_Special_Chars_Unconfined(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+ annotations:
+   seccomp.security.alpha.kubernetes.io/my-Named.Pod: unconfined
+spec:
+ containers:
+   - name: trustworthy-container
+     image: sotrustworthy:latest
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := SeccompAny(json)
+	if containers != 0 {
+		t.Errorf("Got %v containers wanted %v", containers, 0)
+	}
+}
+
+func Test_SeccompAny_Named_Pod_Illegal_Name(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+ annotations:
+   seccomp.security.alpha.kubernetes.io/my-Named.Pod(illegal name): runtime/default
+spec:
+ containers:
+   - name: trustworthy-container
+     image: sotrustworthy:latest
 `
 
 	json, err := yaml.YAMLToJSON([]byte(data))


### PR DESCRIPTION
Has to use regexes here to match a pod name. Have used a-z, A-Z, `-` and `.` as per [docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).

