### PR TITLE
make securityContext.capabilities.drop.ALL rule case insensitive

### DIFF
--- a/pkg/rules/capDropAll.go
+++ b/pkg/rules/capDropAll.go
@@ -15,7 +15,7 @@ func CapDropAll(json []byte) int {
 		From(spec + ".containers").
 		Only("securityContext.capabilities.drop")
 
-	if capDrop != nil && strings.Contains(fmt.Sprintf("%v", capDrop), "ALL") {
+	if capDrop != nil && strings.Contains(strings.ToUpper(fmt.Sprintf("%v", capDrop)), "ALL") {
 		containers++
 	}
 
@@ -23,7 +23,7 @@ func CapDropAll(json []byte) int {
 		From(spec + ".initContainers").
 		Only("securityContext.capabilities.drop")
 
-	if capDropInit != nil && strings.Contains(fmt.Sprintf("%v", capDropInit), "ALL") {
+	if capDropInit != nil && strings.Contains(strings.ToUpper(fmt.Sprintf("%v", capDropInit)), "ALL") {
 		containers++
 	}
 


### PR DESCRIPTION
Currently KubeSec only matches securityContext.capabilities.drop capital `ALL`. This is incorrect as a lower case `all` is perfectly fine. A lowercase `all` is for example used in the Coredns deployment manifest (my commit) or your documentation: https://kubesec.io/basics/containers-securitycontext-capabilities-drop-index-all/


