### PR TITLE
feat: add allowPrivilegeEscalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,13 @@ $ curl -sSX POST --data-binary @test/asset/score-0-cap-sys-admin.yml http://loca
       "critical": [
         {
           "selector": "containers[] .securityContext .capabilities .add == SYS_ADMIN",
-          "reason": "CAP_SYS_ADMIN is the most privileged capability and should always be avoided"
+          "reason": "CAP_SYS_ADMIN is the most privileged capability and should always be avoided",
+          "points": -30
         },
         {
           "selector": "containers[] .securityContext .runAsNonRoot == true",
-          "reason": "Force the running image to run as a non-root user to ensure least privilege"
+          "reason": "Force the running image to run as a non-root user to ensure least privilege",
+          "points": 1
         },
   // ...
 ```
@@ -198,13 +200,15 @@ Kubesec returns a returns a JSON array, and can scan multiple YAML documents in 
       "critical": [
         {
           "selector": "containers[] .securityContext .capabilities .add == SYS_ADMIN",
-          "reason": "CAP_SYS_ADMIN is the most privileged capability and should always be avoided"
+          "reason": "CAP_SYS_ADMIN is the most privileged capability and should always be avoided",
+          "points": -30
         }
       ],
       "advise": [
         {
           "selector": "containers[] .securityContext .runAsNonRoot == true",
-          "reason": "Force the running image to run as a non-root user to ensure least privilege"
+          "reason": "Force the running image to run as a non-root user to ensure least privilege",
+          "points": 1
         },
         {
           // ...
@@ -245,6 +249,12 @@ If you have any questions about Kubesec and Kubernetes security:
 Your feedback is always welcome!
 
 # Release Notes
+
+## 2.1.0
+
+- add rule for `allowPrivilegeEscalation: true` with a score of -7
+- add `points` field to each recommendation so the values that comprise the total score can be seen
+- fix case sensitivity bug in `.capabilities.drop | index("ALL")`
 
 ## 2.0.0
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,10 +6,10 @@ steps:
     args:
       - '-c'
       - |
-        if [[ "${BRANCH_NAME}" == "master" ]]; then docker push gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA}; fi
+        set -euxo pipefail; if [[ "${BRANCH_NAME}" == "master" ]]; then docker push gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA}; fi
   - name: 'gcr.io/cloud-builders/gcloud'
     entrypoint: 'bash'
     args:
       - '-c'
       - |
-        if [[ "${BRANCH_NAME}" == "master" ]]; then gcloud beta run deploy kubesec --image gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA} --region us-central1; fi
+        set -euxo pipefail; if [[ "${BRANCH_NAME}" == "master" ]]; then gcloud beta run deploy kubesec --image gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA} --platform managed --region us-central1; fi

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -230,6 +230,15 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 	}
 	list = append(list, volumeClaimRequestsStorage)
 
+	allowPrivilegeEscalation := Rule{
+		Predicate: rules.AllowPrivilegeEscalation,
+		Selector:  "containers[] .securityContext .allowPrivilegeEscalation == true",
+		Reason:    "",
+		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
+		Points:    -7,
+	}
+	list = append(list, allowPrivilegeEscalation)
+
 	return &Ruleset{
 		Rules:  list,
 		logger: logger,

--- a/pkg/rules/allowPrivilegeEscalation.go
+++ b/pkg/rules/allowPrivilegeEscalation.go
@@ -1,0 +1,24 @@
+package rules
+
+import (
+	"bytes"
+	"github.com/thedevsaddam/gojsonq"
+)
+
+func AllowPrivilegeEscalation(json []byte) int {
+	spec := getSpecSelector(json)
+
+	jqContainers := gojsonq.New().Reader(bytes.NewReader(json)).
+		From(spec+".containers").
+		Where("securityContext", "!=", nil).
+		Where("securityContext.allowPrivilegeEscalation", "!=", nil).
+		Where("securityContext.allowPrivilegeEscalation", "=", true)
+
+	jqInitContainers := gojsonq.New().Reader(bytes.NewReader(json)).
+		From(spec+".initContainers").
+		Where("securityContext", "!=", nil).
+		Where("securityContext.allowPrivilegeEscalation", "!=", nil).
+		Where("securityContext.allowPrivilegeEscalation", "=", true)
+
+	return jqContainers.Count() + jqInitContainers.Count()
+}

--- a/pkg/rules/allowPrivilegeEscalation_test.go
+++ b/pkg/rules/allowPrivilegeEscalation_test.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"github.com/ghodss/yaml"
+	"testing"
+)
+
+func Test_AllowPrivilegeEscalation(t *testing.T) {
+	var data = `
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: c1
+          securityContext:
+            allowPrivilegeEscalation: true
+        - name: c2
+          securityContext:
+            allowPrivilegeEscalation: true
+        - name: c3
+          securityContext:
+            allowPrivilegeEscalation: true
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := AllowPrivilegeEscalation(json)
+	if containers != 3 {
+		t.Errorf("Got %v containers wanted %v", containers, 3)
+	}
+}
+
+func Test_AllowPrivilegeEscalation_InitContainers(t *testing.T) {
+	var data = `
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: init1
+          securityContext:
+            allowPrivilegeEscalation: true
+        - name: init2
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: init3
+      containers:
+        - name: c1
+        - name: c2
+          securityContext:
+            allowPrivilegeEscalation: false
+        - name: c3
+          securityContext:
+            allowPrivilegeEscalation: true
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := AllowPrivilegeEscalation(json)
+	if containers != 2 {
+		t.Errorf("Got %v containers wanted %v", containers, 2)
+	}
+}

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -131,3 +131,9 @@ teardown() {
 
   assert_gt_zero_points
 }
+
+@test "fails deployment with allowPrivilegeEscalation" {
+  run _app ${TEST_DIR}/asset/allowPrivilegeEscalation.yaml
+
+  assert_lt_zero_points
+}

--- a/test/asset/allowPrivilegeEscalation.yaml
+++ b/test/asset/allowPrivilegeEscalation.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: teamcity-server
+  namespace: deployer
+  labels:
+    app: teamcity-server
+spec:
+  selector:
+    matchLabels:
+      app: teamcity-server
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: teamcity-server
+    spec:
+      containers:
+        - image: jetbrains/teamcity-server:2019.1-linux
+          imagePullPolicy: IfNotPresent
+          name: teamcity-server
+          ports:
+            - containerPort: 8111
+              protocol: TCP
+          env:
+            - name: TEAMCITY_SERVER_MEM_OPTS
+              valueFrom:
+                configMapKeyRef:
+                  name: teamcity-server-env
+                  key: MEM_OPTS_VALUE
+          securityContext:
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - mountPath: /data/teamcity_server/datadir
+              name: teamcity-server-storage
+            - mountPath: /opt/teamcity/logs
+              name: logs
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: teamcity-server-storage
+          persistentVolumeClaim:
+            claimName: teamcity-server-config
+        - hostPath:
+            path: /mnt/logs
+            type: DirectoryOrCreate
+          name: logs
+      serviceAccountName: teamcity-service-account


### PR DESCRIPTION
Closes https://github.com/controlplaneio/kubesec/issues/51

Score of `-7` is less than mounted Docker socket (`-9`) or `CAP_SYS_ADMIN` (`-30`). 

(Would like to review and publish the scores at some point, perhaps just adding them to the YAML output is a good start @stefanprodan?)