### PR TITLE
feat: only push and deploy docker image from master

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,14 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'gcr.io/$PROJECT_ID/kubesec:${SHORT_SHA}', '.']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ["push", "gcr.io/$PROJECT_ID/kubesec:${SHORT_SHA}"]
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "${BRANCH_NAME}" == "master" ]]; then docker push gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA}; fi
   - name: 'gcr.io/cloud-builders/gcloud'
-    args: ['beta', 'run', 'deploy', 'kubesec', '--image', 'gcr.io/$PROJECT_ID/kubesec:${SHORT_SHA}', '--region', 'us-central1']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [[ "${BRANCH_NAME}" == "master" ]]; then gcloud beta run deploy kubesec --image gcr.io/${PROJECT_ID}/kubesec:${SHORT_SHA} --region us-central1; fi


### PR DESCRIPTION
This can be done in the cloudbuild console, but is safer in code IMHO.

Contributes towards https://github.com/controlplaneio/kubesec/issues/29 -- although need to add release process for tags.