### PR TITLE
Dockerfile tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ RUN addgroup -S app \
 WORKDIR /home/app
 
 COPY --from=builder /go/src/github.com/controlplaneio/kubesec/kubesec .
-RUN chown -R app:app ./
-
 COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/kubernetes-json-schema/master/master-standalone
-RUN chown -R app:app /schemas
+
+RUN chown -R app:app ./ /schemas
 
 USER app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.12 AS builder
 
-RUN mkdir -p /go/src/github.com/controlplaneio/kubesec/
-
 WORKDIR /go/src/github.com/controlplaneio/kubesec
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh


### PR DESCRIPTION
* `WORKDIR` will create the directory if it's missing so no `mkdir` required

```Dockerfile
FROM alpine:3.8
RUN pwd
WORKDIR /hello/something
RUN pwd
RUN ls -l /hello
```

```sh
Sending build context to Docker daemon  56.34MB

Step 1/5 : FROM alpine:3.8
 ---> dac705114996
Step 2/5 : RUN pwd
 ---> Using cache
 ---> 27bed39e9108
Step 3/5 : WORKDIR /hello/something
 ---> Using cache
 ---> 4237c801719b
Step 4/5 : RUN pwd
 ---> Using cache
 ---> 35635c48c6a5
Step 5/5 : RUN ls -l /hello
 ---> Running in 13a7306814ea
total 4
drwxr-xr-x    2 root     root          4096 Oct 29 17:17 something
Removing intermediate container 13a7306814ea
 ---> 0d1eabeca160
Successfully built 0d1eabeca160
Successfully tagged tmp:latest
```

* `chmod` can take multiple targets/arguments

```bash
$ docker run -it alpine /bin/sh
/ # mkdir /home/app
/ # mkdir /schemas
/ # ls -al /home/app /schemas
/home/app:
total 8
drwxr-xr-x    2 root     root          4096 Oct 29 17:24 .
drwxr-xr-x    1 root     root          4096 Oct 29 17:24 ..

/schemas:
total 8
drwxr-xr-x    2 root     root          4096 Oct 29 17:24 .
drwxr-xr-x    1 root     root          4096 Oct 29 17:24 ..
/ # addgroup -S app && adduser -S -g app app
/ # chown -R app:app /home/app /schemas
/ # ls -al /home/app /schemas
/home/app:
total 8
drwxr-sr-x    2 app      app           4096 Oct 29 17:24 .
drwxr-xr-x    1 root     root          4096 Oct 29 17:24 ..

/schemas:
total 8
drwxr-xr-x    2 app      app           4096 Oct 29 17:24 .
drwxr-xr-x    1 root     root          4096 Oct 29 17:24 ..
/ # whoami
root
```