### PR TITLE
Scratch dockerfile

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,0 +1,23 @@
+FROM golang:1.12-alpine AS builder
+
+WORKDIR /go/src/github.com/controlplaneio/kubesec
+RUN wget https://raw.githubusercontent.com/golang/dep/master/install.sh -O- | sh && \
+    apk add --no-cache git ca-certificates
+COPY . .
+RUN dep ensure -v -vendor-only && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kubesec/*
+RUN echo "kubesec:x:31012:31012:kubesec:/home/kubesec:/sbin/nologin" > /passwd && \
+    echo "kubesec:x:31012:" > /group
+
+# ===
+
+FROM scratch
+WORKDIR /home/kubesec
+COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/kubernetes-json-schema/master/master-standalone
+COPY --from=builder /go/src/github.com/controlplaneio/kubesec/kubesec .
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /passwd /group /etc/
+USER kubesec
+
+ENTRYPOINT ["./kubesec"]
+CMD ["http", "8080"]


### PR DESCRIPTION
Not sure how we want to handle multiple Dockerfiles, automate the build, etc.
I'll post this as a draft for now. Suggestions for ^^^ welcome.


Output from `REMOTE_URL="http://localhost:8080" make test-remote` against the container running on `8080`

```
+ test-remote
bash -xc 'cd test && REMOTE_URL=http://localhost:8080 ./bin/bats/bin/bats  .'
1..48
ok 1 fails Pod with unconfined seccomp
ok 2 fails with CAP_SYS_ADMIN
ok 3 fails with CAP_CHOWN
ok 4 fails with CAP_SYS_ADMIN and CAP_CHOWN
ok 5 passes with securityContext capabilities drop all
ok 6 passes deployment with securitycontext readOnlyRootFilesystem
ok 7 passes deployment with securitycontext runAsNonRoot
ok 8 fails deployment with securitycontext runAsUser 1
ok 9 passes deployment with securitycontext runAsUser > 10000
ok 10 fails deployment with empty security context
ok 11 passes deployment with cgroup resource limits
ok 12 passes deployment with cgroup memory limits
ok 13 passes StatefulSet with volumeClaimTemplate
ok 14 fails StatefulSet with no security
ok 15 fails DaemonSet with securityContext.privileged = true
ok 16 fails DaemonSet with mounted host docker.sock
ok 17 passes Pod with apparmor annotation
ok 18 fails Pod with unconfined seccomp for all containers
ok 19 passes Pod with non-unconfined seccomp for all containers
ok 20 fails DaemonSet with hostNetwork
ok 21 fails DaemonSet with hostPid
ok 22 fails DaemonSet with host docker.socket
ok 23 passes Deployment with serviceaccountname
ok 24 passes pod with serviceaccountname
ok 25 only valid types - allow Pod
ok 26 only valid types - allow Deployment
ok 27 only valid types - allow StatefulSet
ok 28 only valid types - allow DaemonSet
ok 29 only valid types - deny PodSecurityPolicy
ok 30 passes 1.11 format daemonset
ok 31 passes 1.11 format statefulset
ok 32 returns error for invalid JSON
ok 33 returns error YAML control characters
ok 34 passes bug dump twice [1/2]
ok 35 passes bug dump twice [2/2]
ok 36 errors with no filename
ok 37 errors with invalid file
ok 38 errors with empty file
ok 39 errors with empty file (json, local) # skip
ok 40 errors with empty file (json, remote)
ok 41 errors with empty JSON (json, local) # skip
ok 42 errors with empty JSON (json, remote)
ok 43 returns content-type application/json on pass
ok 44 fix multipart form bug
ok 45 passes production dump
ok 46 TODO: passes DaemonSet with apparmor loader # skip
ok 47 TODO: passes Deployment with serviceaccountname # skip
ok 48 TODO: fails DaemonSet with loads o' permutations # skip
```