### PR TITLE
test: ensure line assertions match local/remote

### DIFF
--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -133,11 +133,11 @@ teardown() {
 }
 
 @test "returns a unordered point score for specific response lines" {
-  # NB response from use of parallel results in different permutations of rule order
+  # ordering of scoring rules output currently non-determinstic, to be ordered in #44
   run \
     _app ${TEST_DIR}/asset/score-2-pod-serviceaccount.yml
-  for LINE in 11 16 21 26 31 36 41 46 51 56 61
-  do
+
+  for LINE in 11 16 21 26 31 36 41 46 51 56 61; do
     assert_line --index ${LINE} --regexp '^.*"points": [0-9]+$'
   done
 }
@@ -148,9 +148,10 @@ teardown() {
 
   run \
     _app ${TEST_DIR}/asset/score-2-pod-serviceaccount.yml
+
   assert_line --index 11 --regexp '^.*\"points\": 3$'
-  for LINE in 16 21 26 31 36 41 46 51 56 61
-  do 
+
+  for LINE in 16 21 26 31 36 41 46 51 56 61; do
     assert_line --index ${LINE} --regexp '^.*\"points\": 1$'
   done
 }

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -36,8 +36,8 @@ if _is_remote; then
     shift
     local ARGS="${@:-}"
     ARGS=$(echo "${ARGS}" | sed 's,--json,,g')
-    echo curl -v -sSX POST --data-binary @"${FILE}" ${ARGS} "$(_get_remote_url)"
-    curl -v -sSX POST --data-binary @"${FILE}" ${ARGS} "$(_get_remote_url)"
+    # echo \# curl -sSX POST --data-binary @"${FILE}" ${ARGS} "$(_get_remote_url)" >&3
+    curl -sSX POST --data-binary @"${FILE}" ${ARGS} "$(_get_remote_url)"
   }
 
   assert_gt_zero_points() {


### PR DESCRIPTION
When deployed to cloud run, the `make test-acceptance` test were asserting against the index of a specific line that was bumped by one due to `curl` debug output.

This change changes that debug to point to FD 3 (bats' debug output) and prefixes with a hash for TAP compliance. Then it comments out the debug because we don't need it.