### PR TITLE
Add github action based on goreleaser to release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+on:
+  create:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GO
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+        id: go
+      - name: set up dep
+        run: |
+          export GOBIN=${GOROOT}/bin
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      - name: Set GOPATH
+        run: |
+          echo "##[set-env name=GOPATH;]$(dirname `pwd`)"
+          echo "##[add-path]$(dirname `pwd`)/bin"
+        shell: bash
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          path: src/github.com/controlplaneio/kubesec/
+      - name: Launch goreleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          args: release --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,18 @@ builds:
       - linux
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=0
+      - 386
     ignore:
       - goos: darwin
         goarch: 386
+    env:
+      - CGO_ENABLED=0
 
-archive:
-  name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  files:
-    - none*
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
 
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
Improve `.goreleaser.yml` file and add Github action based on goreleaser, in order to release binaries when a new tag is created with the format `v*.*.*`.

This solves issue https://github.com/controlplaneio/kubesec/issues/53.

Since `dep` is being used for dependencies management, and it forces to follow certain directory structure, some black magic needs to be done in file `release.yml`:

-  "Set GOPATH" step in order to set  GOPATH env to the folder where repository is going to be checked out.
- Check out the code under the following path: `${GOPATH}/src/github.com/controlplaneio/kubesec/`