### PR TITLE
feat: magnitude ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This uses ControlPlane's hosted API at [v2.kubesec.io/scan](https://v2.kubesec.i
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Release Notes](#release-notes)
+  - [2.1.0](#210)
   - [2.0.0](#200)
   - [1.0.0](#100)
 
@@ -251,12 +252,12 @@ Your feedback is always welcome!
 
 # Release Notes
 
-## 2.1.0-dev (unreleased)
+## 2.1.0
 
 - add rule for `allowPrivilegeEscalation: true` with a score of -7
 - add `points` field to each recommendation so the values that comprise the total score can be seen
 - fix case sensitivity bug in `.capabilities.drop | index("ALL")`
-- output now sorted - lowest `points` first, and same rule reporting order across runs
+- rules in `critical` and `advise` lists prioritised and returned in same order across runs
 
 ## 2.0.0
 

--- a/pkg/ruler/report.go
+++ b/pkg/ruler/report.go
@@ -36,7 +36,12 @@ func (rr RuleRefCustomOrder) Swap(i, j int) { rr[i], rr[j] = rr[j], rr[i] }
 
 func (rr RuleRefCustomOrder) Less(i, j int) bool {
 	if rr[i].Points != rr[j].Points {
-		return rr[i].Points < rr[j].Points
+		// no integer absolute fn in golang
+		if rr[i].Points > 0 || rr[j].Points > 0 {
+			return rr[i].Points > rr[j].Points
+		} else {
+			return rr[i].Points < rr[j].Points
+		}
 	}
 	return rr[i].Selector < rr[j].Selector
 }

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -138,7 +138,7 @@ teardown() {
   assert_lt_zero_points
 }
 
-@test "returns a unordered point score for specific response lines" {
+@test "returns integer point score for specific response lines" {
   # ordering of scoring rules output currently non-determinstic, to be ordered in #44
   run \
     _app ${TEST_DIR}/asset/score-2-pod-serviceaccount.yml
@@ -152,11 +152,25 @@ teardown() {
   run \
     _app ${TEST_DIR}/asset/score-2-pod-serviceaccount.yml
 
-  assert_line --index 61 --regexp '^.*\"points\": 3$'
+  assert_line --index 11 --regexp '^.*\"points\": 3$'
 
-  for LINE in 11 16 21 26 31 36 41 46 51 56; do
+  for LINE in 16 21 26 31 36 41 46 51 56 61; do
     assert_line --index ${LINE} --regexp '^.*\"points\": 1$'
   done
+}
+
+@test "check critical and advisory points listed by magnitude" {
+  run \
+    _app ${TEST_DIR}/asset/critical-double.yml
+
+  # criticals - magnitude sort/lowest number first
+  assert_line --index 11 --regexp '^.*\"points\": -30$'
+  assert_line --index 16 --regexp '^.*\"points\": -7$'
+
+  # advisories - magnitude sort/highest number first
+  assert_line --index 23 --regexp '^.*\"points\": 3$'
+  assert_line --index 28 --regexp '^.*\"points\": 3$'
+  assert_line --index 33 --regexp '^.*\"points\": 1$'  
 }
 
 @test "returns deterministic report output" {
@@ -180,7 +194,6 @@ teardown() {
   assert_success
 
   RUN_3_SIGNATURE=$(echo "${output}" | sha1sum)
-
   [ "${RUN_1_SIGNATURE}" == "${RUN_2_SIGNATURE}" ]
   [ "${RUN_1_SIGNATURE}" == "${RUN_3_SIGNATURE}" ]
 }

--- a/test/asset/critical-double.yml
+++ b/test/asset/critical-double.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true
+


### PR DESCRIPTION
Changed ordering from numeric to magnitude. Lowest numbered criticals first; highest advises first.