### PR TITLE
server: add in-toto support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,6 +77,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:4959330ba7cf8c93dbbfdeb7e724e27273f736e6fb77261d3ad14533c8f2c293"
+  name = "github.com/in-toto/in-toto-golang"
+  packages = ["in_toto"]
+  pruneopts = "UT"
+  revision = "857cd1cfa826f39ecdf9bd98815eb3e5a312cdb9"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
@@ -276,6 +284,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:cd7e85fc3687e062714febdee3e8efeb00a413a2a620d28908fd0258261d2353"
+  name = "golang.org/x/crypto"
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+  ]
+  pruneopts = "UT"
+  revision = "bd318be0434a57050ed475e0f45c3dbb16c09c2e"
+
+[[projects]]
+  branch = "master"
   digest = "1:8b466798e96432c23185ca32826702885299f94eb644c9a8dedb79771dff383a"
   name = "golang.org/x/sys"
   packages = ["unix"]
@@ -311,6 +330,7 @@
   input-imports = [
     "github.com/garethr/kubeval/kubeval",
     "github.com/ghodss/yaml",
+    "github.com/in-toto/in-toto-golang/in_toto",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/spf13/cobra",
     "github.com/thedevsaddam/gojsonq",

--- a/cmd/kubesec/http.go
+++ b/cmd/kubesec/http.go
@@ -10,6 +10,10 @@ import (
 )
 
 func init() {
+	// FIXME: I don't understand why I need a reference to keypath here,
+	// and the cobra docs don't make it exactly clear.
+	var keypath string
+	httpCmd.Flags().StringVarP(&keypath, "keypath", "k", "", "Path to in-toto link signing key")
 	rootCmd.AddCommand(httpCmd)
 }
 
@@ -33,7 +37,9 @@ var httpCmd = &cobra.Command{
 		stopCh := server.SetupSignalHandler()
 		jsonLogger, _ := NewLogger("info", "json")
 
-		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh)
+		keypath := cmd.Flag("keypath").Value.String()
+
+		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath)
 		return nil
 	},
 }

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -2,11 +2,13 @@ package ruler
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"github.com/controlplaneio/kubesec/pkg/rules"
 	"github.com/garethr/kubeval/kubeval"
 	"github.com/ghodss/yaml"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/thedevsaddam/gojsonq"
 	"go.uber.org/zap"
 	"runtime"
@@ -268,6 +270,38 @@ func (rs *Ruleset) Run(fileBytes []byte) ([]Report, error) {
 	}
 
 	return reports, nil
+}
+
+func GenerateInTotoLink(reports []Report, fileBytes []byte) in_toto.Metablock {
+
+	var linkMb in_toto.Metablock
+
+	materials := make(map[string]interface{})
+	request := make(map[string]interface{})
+	request["sha256"] = fmt.Sprintf("%x", sha256.Sum256([]uint8(fileBytes)))
+	materials["request"] = request
+
+	products := make(map[string]interface{})
+	for _, report := range reports {
+		reportArtifact := make(map[string]interface{})
+		// FIXME: encoding as json now for integrity check, this is the wrong way
+		// to compute the hash over the result. Also, some error checking would be
+		// more than ideal.
+		reportValue, _ := json.Marshal(report)
+		reportArtifact["sha256"] =
+			fmt.Sprintf("%x", sha256.Sum256([]uint8(reportValue)))
+		products[report.Object] = reportArtifact
+	}
+
+	linkMb.Signatures = []in_toto.Signature{}
+	linkMb.Signed = in_toto.Link{
+		Type:      "link",
+		Name:      "kubesec",
+		Materials: materials,
+		Products:  products,
+	}
+
+	return linkMb
 }
 
 func (rs *Ruleset) generateReport(json []byte) Report {


### PR DESCRIPTION
This PR adds support for generating signed reports as link metadata:

I.e., running your server with the newly optional flag `-k <path>` will let you answer to queries using the fragment `in-toto=` for the `scan` endpoint:

```
[santiago@LykOS kubesec]$ ./kubesec http 8080 -k somekey 
{"severity":"info","timestamp":"2019-11-11T13:15:55.934-0500","caller":"server/server.go:39","message":"Starting HTTP server on port 8080"}
```

To generate a link you simply can: 
```
[santiago@LykOS kubesec]$ curl --data "$(cat test/asset/score-1-dep-default.yml )" localhost:8080/scan?in-toto=1 | jq .link
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3771    0  3562  100   209    692     40  0:00:05  0:00:05 --:--:--   902
{
  "signed": {
    "_type": "link",
    "name": "kubesec",
    "materials": {
      "request": {
        "sha256": "707467120ae4e2757c2ccea9c231c881d01bdb6c2bead472e944d7cfca61bced"
      }
    },
    "products": {
      "Deployment/undefined.default": {
        "sha256": "4b02966bbf0a05e9eb1fd7fd7f6a735ea785ffd83349a7432a58af4642f89d3f"
      }
    },
    "byproducts": null,
    "command": null,
    "environment": null
  },
  "signatures": [
    {
      "keyid": "e26d1dad7f6605f2bc5303d0c80bfc2fe52257d1cb7bb1f981f099ab5fb7f619",
      "sig": "5a15c1d1f5c7b1d6bfc256ee12e6af282f6498cde13b33da0b2da78ae73b7b0fc839f2a274de5f8100dd461f7ad12c22aec1b758b885405b7e833c436c6a2301"
    }
  ]
}
```

Notice the reply becomes:
```
{ reports: <the usual response payload>,
  link: <the signed attestation for this run
}
```

This will hash/sign the materials of the payload received (i.e., the deployment name) and then a series of products (i.e., the reports returned) and sign them using the provided ed25519 key.