### PR TITLE
Add multi-yaml test and move repeated sorting from scan/server into ruleset

### DIFF
--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
-	"sort"
 )
 
 type ScanFailedValidationError struct {
@@ -71,18 +70,6 @@ var scanCmd = &cobra.Command{
 			if r.Score <= 0 {
 				lowScore = true
 				break
-			}
-		}
-
-		// Sort reports into custom order
-		for _, r := range reports {
-			if r.Valid {
-				if len(r.Scoring.Critical) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Critical))
-				}
-				if len(r.Scoring.Advise) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Advise))
-				}
 			}
 		}
 

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thedevsaddam/gojsonq"
 	"go.uber.org/zap"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -350,6 +351,10 @@ func (rs *Ruleset) generateReport(json []byte) Report {
 	} else {
 		report.Message = fmt.Sprintf("Failed with a score of %v points", report.Score)
 	}
+
+	// sort results into priority order
+	sort.Sort(RuleRefCustomOrder(report.Scoring.Critical))
+	sort.Sort(RuleRefCustomOrder(report.Scoring.Advise))
 
 	return report
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sort"
 	"syscall"
 	"time"
 
@@ -101,18 +100,6 @@ func scanHandler(logger *zap.SugaredLogger) http.Handler {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error() + "\n"))
 			return
-		}
-
-		// Sort reports into custom order (to be refactored!)
-		for _, r := range reports {
-			if r.Valid {
-				if len(r.Scoring.Critical) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Critical))
-				}
-				if len(r.Scoring.Advise) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Advise))
-				}
-			}
 		}
 
 		res, err := json.Marshal(reports)

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -173,6 +173,29 @@ teardown() {
   assert_line --index 33 --regexp '^.*\"points\": 1$'  
 }
 
+@test "check critical and advisory points as multi-yaml" {
+  run \
+    _app ${TEST_DIR}/asset/critical-double-multiple.yml
+
+  # report 1 - criticals - magnitude sort/lowest number first
+  assert_line --index 11 --regexp '^.*\"points\": -30$'
+  assert_line --index 16 --regexp '^.*\"points\": -7$'
+
+  # report 1 - advisories - magnitude sort/highest number first
+  assert_line --index 23 --regexp '^.*\"points\": 3$'
+  assert_line --index 28 --regexp '^.*\"points\": 3$'
+  assert_line --index 33 --regexp '^.*\"points\": 1$'  
+
+  # report 2 - criticals - magnitude sort/lowest number first
+  assert_line --index 93 --regexp '^.*\"points\": -30$'
+  assert_line --index 98 --regexp '^.*\"points\": -7$'
+
+  # report 2 - advisories - magnitude sort/highest number first
+  assert_line --index 105 --regexp '^.*\"points\": 3$'
+  assert_line --index 110 --regexp '^.*\"points\": 3$'
+  assert_line --index 115 --regexp '^.*\"points\": 1$'  
+}
+
 @test "returns deterministic report output" {
   run \
     _app ${TEST_DIR}/asset/score-2-pod-serviceaccount.yml

--- a/test/asset/critical-double-multiple.yml
+++ b/test/asset/critical-double-multiple.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true

--- a/test/asset/critical-double.yml
+++ b/test/asset/critical-double.yml
@@ -9,4 +9,3 @@ spec:
     securityContext:
       allowPrivilegeEscalation: true
       privileged: true
-


### PR DESCRIPTION
Adds multi-yaml (two yamls in one file split with '---') testing

Refactor duplicated report ordering code - sorting removed from scan/server and added into ruleset