### PR TITLE
Fixed the tests for the go-mod branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+on:
+  create:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    name: Release on GitHub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up GO
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+        id: go
+      - name: set up dep
+        run: |
+          export GOBIN=${GOROOT}/bin
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      - name: Set GOPATH
+        run: |
+          echo "##[set-env name=GOPATH;]$(dirname `pwd`)"
+          echo "##[add-path]$(dirname `pwd`)/bin"
+        shell: bash
+      - name: Check out code
+        uses: actions/checkout@v1
+        with:
+          path: src/github.com/controlplaneio/kubesec/
+      - name: Launch goreleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          args: release --debug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,27 +9,18 @@ jobs:
     name: Release on GitHub
     runs-on: ubuntu-latest
     steps:
-      - name: Set up GO
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: 1.13
         id: go
-      - name: set up dep
-        run: |
-          export GOBIN=${GOROOT}/bin
-          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-      - name: Set GOPATH
-        run: |
-          echo "##[set-env name=GOPATH;]$(dirname `pwd`)"
-          echo "##[add-path]$(dirname `pwd`)/bin"
-        shell: bash
+
       - name: Check out code
         uses: actions/checkout@v1
-        with:
-          path: src/github.com/controlplaneio/kubesec/
+
       - name: Launch goreleaser
         uses: goreleaser/goreleaser-action@master
         with:
-          args: release --debug
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,18 @@ builds:
       - linux
     goarch:
       - amd64
-    env:
-      - CGO_ENABLED=0
+      - 386
     ignore:
       - goos: darwin
         goarch: 386
+    env:
+      - CGO_ENABLED=0
 
-archive:
-  name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  files:
-    - none*
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 before:
   hooks:
-    - dep ensure -vendor-only
+    - go mod tidy
 
 builds:
   - main: ./cmd/kubesec

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
 script:
 - set -e
 - make lint
-- curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./pkg/...
 - make build test-acceptance
 - docker build -t kubesec .

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ script:
 - docker build -t kubesec .
 - docker run -dp 8080:8080 kubesec
 - sleep 1
-- curl -sSX POST --data-binary @test/asset/score-0-daemonset-host-network.yml http://localhost:8080/scan | grep loopback
-- curl -sSX POST --data-binary @test/asset/invalid-schema.yml http://localhost:8080/scan | grep Invalid
+- REMOTE_URL="http://localhost:8080" make test-remote
 
 after_success:
 - if [ -z "$DOCKER_USER" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,3 @@ after_success:
     echo $DOCKER_PASS | docker login -u=$DOCKER_USER --password-stdin;
     docker push kubesec/kubesec:${BRANCH_COMMIT};
   fi
-
-deploy:
-- provider: script
-  skip_cleanup: true
-  script: curl -sL http://git.io/goreleaser | bash
-  on:
-    branch: master
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,15 @@ script:
 - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./pkg/...
 - make build test-acceptance
 - docker build -t kubesec .
-- docker run -dp 8080:8080 kubesec
+- docker run -dp 8080:8080 --name kubesec kubesec
 - sleep 1
 - REMOTE_URL="http://localhost:8080" make test-remote
+- docker kill kubesec
+- docker build -t kubesecscratch .
+- docker run -dp 8080:8080 --name kubesecscratch kubesecscratch
+- sleep 1
+- REMOTE_URL="http://localhost:8080" make test-remote
+- docker kill kubesecscratch
 
 after_success:
 - if [ -z "$DOCKER_USER" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM golang:1.13 AS builder
 
-WORKDIR /go/src/github.com/controlplaneio/kubesec
-
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+WORKDIR /kubesec
 
 COPY . .
 
-RUN dep ensure -v -vendor-only \
-  && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kubesec/*
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kubesec/*
 
 # ===
 
@@ -19,8 +16,8 @@ RUN addgroup -S app \
 
 WORKDIR /home/app
 
-COPY --from=builder /go/src/github.com/controlplaneio/kubesec/kubesec .
-COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/kubernetes-json-schema/master/master-standalone
+COPY --from=builder /kubesec/kubesec .
+COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/master-standalone-strict
 
 RUN chown -R app:app ./ /schemas
 

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -1,20 +1,18 @@
 FROM golang:1.13-alpine AS builder
 
-WORKDIR /go/src/github.com/controlplaneio/kubesec
-RUN wget https://raw.githubusercontent.com/golang/dep/master/install.sh -O- | sh && \
-    apk add --no-cache git ca-certificates
-COPY . .
-RUN dep ensure -v -vendor-only && \
-    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kubesec/*
 RUN echo "kubesec:x:31012:31012:kubesec:/home/kubesec:/sbin/nologin" > /passwd && \
     echo "kubesec:x:31012:" > /group
+WORKDIR /kubesec
+RUN apk add --no-cache git ca-certificates
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kubesec/*
 
 # ===
 
 FROM scratch
 WORKDIR /home/kubesec
 COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/kubernetes-json-schema/master/master-standalone
-COPY --from=builder /go/src/github.com/controlplaneio/kubesec/kubesec .
+COPY --from=builder /kubesec .
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /passwd /group /etc/
 USER kubesec

--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec ./cmd/kub
 
 FROM scratch
 WORKDIR /home/kubesec
-COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/kubernetes-json-schema/master/master-standalone
+COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/master-standalone-strict
 COPY --from=builder /kubesec .
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /passwd /group /etc/

--- a/Makefile
+++ b/Makefile
@@ -116,16 +116,10 @@ build: ## golang build
 	@echo "+ $@"
 	go build -a -o ./dist/kubesec ./cmd/kubesec/*.go
 
-.PHONY: dep
-dep: ## golang and deployment dependencies
-	@echo "+ $@"
-	command -v up &>/dev/null || curl -sfL https://raw.githubusercontent.com/apex/up/master/install.sh | sudo sh
-	dep ensure -v
-
 .PHONY: prune
 prune: ## golang dependency prune
 	@echo "+ $@"
-	dep prune -v
+	go mod tidy
 
 # ---
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This uses ControlPlane's hosted API at [v2.kubesec.io/scan](https://v2.kubesec.i
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Release Notes](#release-notes)
+  - [2.2.0](#220)
   - [2.1.0](#210)
   - [2.0.0](#200)
   - [1.0.0](#100)
@@ -251,6 +252,10 @@ If you have any questions about Kubesec and Kubernetes security:
 Your feedback is always welcome!
 
 # Release Notes
+
+## 2.2.0
+
+- added in-toto support
 
 ## 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This uses ControlPlane's hosted API at [v2.kubesec.io/scan](https://v2.kubesec.i
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Release Notes](#release-notes)
+  - [2.3.0](#230)
   - [2.2.0](#220)
   - [2.1.0](#210)
   - [2.0.0](#200)
@@ -252,6 +253,10 @@ If you have any questions about Kubesec and Kubernetes security:
 Your feedback is always welcome!
 
 # Release Notes
+
+## 2.3.0
+
+- moved everything to go modules
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This uses ControlPlane's hosted API at [v2.kubesec.io/scan](https://v2.kubesec.i
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Release Notes](#release-notes)
+  - [2.1.0](#210)
   - [2.0.0](#200)
   - [1.0.0](#100)
 
@@ -251,12 +252,12 @@ Your feedback is always welcome!
 
 # Release Notes
 
-## 2.1.0-dev (unreleased)
+## 2.1.0
 
 - add rule for `allowPrivilegeEscalation: true` with a score of -7
 - add `points` field to each recommendation so the values that comprise the total score can be seen
 - fix case sensitivity bug in `.capabilities.drop | index("ALL")`
-- output now sorted - lowest `points` first, and same rule reporting order across runs
+- rules in `critical` and `advise` lists prioritised and returned in same order across runs
 
 ## 2.0.0
 

--- a/cmd/kubesec/http.go
+++ b/cmd/kubesec/http.go
@@ -10,6 +10,10 @@ import (
 )
 
 func init() {
+	// FIXME: I don't understand why I need a reference to keypath here,
+	// and the cobra docs don't make it exactly clear.
+	var keypath string
+	httpCmd.Flags().StringVarP(&keypath, "keypath", "k", "", "Path to in-toto link signing key")
 	rootCmd.AddCommand(httpCmd)
 }
 
@@ -33,7 +37,9 @@ var httpCmd = &cobra.Command{
 		stopCh := server.SetupSignalHandler()
 		jsonLogger, _ := NewLogger("info", "json")
 
-		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh)
+		keypath := cmd.Flag("keypath").Value.String()
+
+		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath)
 		return nil
 	},
 }

--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
-	"sort"
 )
 
 type ScanFailedValidationError struct {
@@ -71,18 +70,6 @@ var scanCmd = &cobra.Command{
 			if r.Score <= 0 {
 				lowScore = true
 				break
-			}
-		}
-
-		// Sort reports into custom order
-		for _, r := range reports {
-			if r.Valid {
-				if len(r.Scoring.Critical) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Critical))
-				}
-				if len(r.Scoring.Advise) > 1 {
-					sort.Sort(ruler.RuleRefCustomOrder(r.Scoring.Advise))
-				}
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826 // indirect
+	github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/cobra v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826 // indirect
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0 h1:j30noez
 github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826 h1:OCkPSQJNRL2F2gtXsSqmPiJymV3SBkYQVNdhms0gbcM=
+github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826/go.mod h1:g74L6WsLgavXpuPilYTRmx7rWfMBZNPITjiX6vS6DKo=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56 h1:kKOrEaxR9KvCDdnQqjiBxbaeJg/goLvJvW0lno6aWm4=
@@ -141,6 +143,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf h1:fnPsqIDRbCSgumaMCRpoIoF2s4qxv0xSSS0BVZUE/ss=
+golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=

--- a/pkg/ruler/report.go
+++ b/pkg/ruler/report.go
@@ -36,7 +36,12 @@ func (rr RuleRefCustomOrder) Swap(i, j int) { rr[i], rr[j] = rr[j], rr[i] }
 
 func (rr RuleRefCustomOrder) Less(i, j int) bool {
 	if rr[i].Points != rr[j].Points {
-		return rr[i].Points < rr[j].Points
+		// no integer absolute fn in golang
+		if rr[i].Points > 0 || rr[j].Points > 0 {
+			return rr[i].Points > rr[j].Points
+		} else {
+			return rr[i].Points < rr[j].Points
+		}
 	}
 	return rr[i].Selector < rr[j].Selector
 }

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -360,6 +361,10 @@ func (rs *Ruleset) generateReport(json []byte) Report {
 	} else {
 		report.Message = fmt.Sprintf("Failed with a score of %v points", report.Score)
 	}
+
+	// sort results into priority order
+	sort.Sort(RuleRefCustomOrder(report.Scoring.Critical))
+	sort.Sort(RuleRefCustomOrder(report.Scoring.Advise))
 
 	return report
 }

--- a/pkg/ruler/ruleset_test.go
+++ b/pkg/ruler/ruleset_test.go
@@ -2,6 +2,7 @@ package ruler
 
 import (
 	"github.com/ghodss/yaml"
+	"github.com/in-toto/in-toto-golang/in_toto"
 	"go.uber.org/zap"
 	"strings"
 	"testing"
@@ -74,7 +75,7 @@ kind: Deployment
 spec:
   template:
     spec:
-      hostNetwork: 
+      hostNetwork:
       initContainers:
         - name: init1
       containers:
@@ -171,5 +172,53 @@ data:
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "not supported") {
 		t.Errorf("Got error %v ", report.Message)
+	}
+}
+
+func TestRuleset_Get_intoto(t *testing.T) {
+	var data = `
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      initContainers:
+        - name: init1
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: init2
+          securityContext:
+            readOnlyRootFilesystem: false
+        - name: init3
+      containers:
+        - name: c1
+        - name: c2
+          securityContext:
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 1001
+        - name: c3
+          securityContext:
+            readOnlyRootFilesystem: true
+
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var reports []Report
+
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	reports = append(reports, report)
+
+	link := GenerateInTotoLink(reports, []byte(data)).Signed.(in_toto.Link)
+
+	if len(link.Materials) < 1 || len(link.Products) < 1 {
+		t.Errorf("Should have generated a report with at least one material and a product %+v",
+			link)
 	}
 }

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -60,6 +60,11 @@ teardown() {
   assert_zero_points
 }
 
+@test "fails deployment with invalid security context" {
+  run _app ${TEST_DIR}/asset/score-1-dep-invalid-security-context.yml
+  assert_line --index 4 --regexp 'fake: Additional property fake is not allowed'
+}
+
 @test "passes deployment with cgroup resource limits" {
   run _app ${TEST_DIR}/asset/score-1-dep-resource-limit-cpu.yml
   assert_gt_zero_points

--- a/test/2_regression.bats
+++ b/test/2_regression.bats
@@ -62,7 +62,7 @@ teardown() {
 @test "returns error for invalid JSON" {
   run _app ${TEST_DIR}/asset/invalid-input-pod-dump.json
 
-  assert_output --regexp "'api_version': invalid key, expected 'apiVersion'" \
+  assert_output --regexp "Missing 'apiVersion' key" \
     || assert_output --regexp ".*: Invalid type\. .*"
 
   assert_failure_local

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -65,7 +65,7 @@ if _is_remote; then
     assert_output --regexp '  "message": "Invalid input"' \
      || assert_output --regexp ".*Invalid input.*" \
      || assert_output --regexp ".*no such file or directory.*" \
-     || assert_output --regexp ".*Kubernetes kind not found.*"
+     || assert_output --regexp ".*Missing 'kind' key.*"
   }
 
   assert_failure_local() { :; }

--- a/test/asset/critical-double-multiple.yml
+++ b/test/asset/critical-double-multiple.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true

--- a/test/asset/critical-double.yml
+++ b/test/asset/critical-double.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubesec-test
+spec:
+  containers:
+  - name: kubesec-demo
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      allowPrivilegeEscalation: true
+      privileged: true

--- a/test/asset/score-1-dep-empty-security-context.yml
+++ b/test/asset/score-1-dep-empty-security-context.yml
@@ -8,7 +8,13 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
       - name: carts-db

--- a/test/asset/score-1-dep-invalid-security-context.yml
+++ b/test/asset/score-1-dep-invalid-security-context.yml
@@ -8,15 +8,10 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
-  selector:
-    matchLabels:
-      app: carts-db
   template:
-    metadata:
-      labels:
-        app: carts-db
     spec:
       containers:
       - name: carts-db
         image: mongo
         securityContext:
+          fake: entry

--- a/test/asset/score-2-dep-serviceaccount.yml
+++ b/test/asset/score-2-dep-serviceaccount.yml
@@ -5,7 +5,13 @@ metadata:
   namespace: dev
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
   template:
+    metadata:
+      labels:
+        app: prometheus
     spec:
       serviceAccountName: prometheus-sa
       containers:


### PR DESCRIPTION
Fixed the tests for the go-mod branch.

Updates:

* Merged in fix for sorting output from master
* Fixed new formatting for missing keys
* Separated empty and invalid `securityContext` into separate tests
* Added `selector`s and `label`s to `Deployment`s that now require it
* Added full remote acceptance testing into travis-ci to avoid cases like the sorting output issue (it's also quite quick to run)
* Replaced dep with modules in:
  * Dockerfiles
  * Makefile
  * Travis
* Moved the go build in docker outside of the GOPATH as is required by modules

Still to consider:

* **Note:** The code is currently expecting the schemas to be in `/schemas/master-standalone-strict` but they were in `/schemas/kubernetes-json-schema/master/master-standalone` before. Is this an intended change or a bug?
* ~Update go releaser to use modules instead of dep or replace go releaser with whatever~
* ~Remove releaser from travis to just use GH actions?~

The above go releaser considerations probably want #68 merged first