### PR TITLE
81 fix website linting demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This uses ControlPlane's hosted API at [v2.kubesec.io/scan](https://v2.kubesec.i
 - [Contributing](#contributing)
 - [Getting Help](#getting-help)
 - [Release Notes](#release-notes)
+  - [2.3.1](#231)
   - [2.3.0](#230)
   - [2.2.0](#220)
   - [2.1.0](#210)
@@ -253,6 +254,10 @@ If you have any questions about Kubesec and Kubernetes security:
 Your feedback is always welcome!
 
 # Release Notes
+
+## 2.3.1
+
+- patch to accept form data from the <https://kubesec.io> webpage sample form
 
 ## 2.3.0
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/in-toto/in-toto-golang v0.0.0-20191106170227-857cd1cfa826
 	github.com/instrumenta/kubeval v0.0.0-20190918223246-8d013ec9fc56
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/cobra v0.0.5
 	github.com/thedevsaddam/gojsonq v2.3.0+incompatible

--- a/test/2_regression.bats
+++ b/test/2_regression.bats
@@ -158,6 +158,46 @@ teardown() {
   assert_output --regexp "application/json"
 }
 
+@test "strips form 'file=' prefix from YAML (yaml, remote)" {
+  if _is_local; then
+    skip
+  fi
+
+  run _app ${TEST_DIR}/asset/form-prefix-file.yml
+  assert_gt_zero_points
+  assert_success
+}
+
+@test "strips form 'file=' prefix from JSON (json, remote)" {
+  if _is_local; then
+    skip
+  fi
+
+  run _app ${TEST_DIR}/asset/form-prefix-file.json
+  assert_gt_zero_points
+  assert_success
+}
+
+@test "does not strip form 'not-file=' prefix from YAML (yaml, remote)" {
+  if _is_local; then
+    skip
+  fi
+
+  run _app ${TEST_DIR}/asset/form-prefix-not-file.yml
+  assert_output --regexp ".*resource.json: Missing 'apiVersion' key.*"
+  assert_success
+}
+
+@test "does not strip form 'not-file=' prefix from JSON (json, remote)" {
+  if _is_local; then
+    skip
+  fi
+
+  run _app ${TEST_DIR}/asset/form-prefix-not-file.json
+  assert_output "yaml: line 2: mapping values are not allowed in this context"
+  assert_success
+}
+
 @test "fix multipart form bug" {
   run curl -sSX POST --fail "${REMOTE_URL}" -H 'authority: kubesec.io' -H 'cache-control: max-age=0' -H 'origin: https://kubesec.io' -H 'upgrade-insecure-requests: 1' -H 'dnt: 1' -H 'content-type: multipart/form-data; boundary=----WebKitFormBoundaryjh6hXNUDWrzlmi5c' -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36' -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8' -H 'referer: https://kubesec.io/' -H 'accept-encoding: gzip, deflate, br' -H 'accept-language: en-GB,en;q=0.9' -H 'cookie: gsScrollPos-239=0' --data-binary $'------WebKitFormBoundaryjh6hXNUDWrzlmi5c\r\nContent-Disposition: form-data; name="file"\r\n\r\napiVersion: v1\r\nkind: Pod\r\nmetadata:\r\n  annotations:\r\n    scheduler.alpha.kubernetes.io/critical-pod: ""\r\n  creationTimestamp: 2018-07-16T01:48:24Z\r\n  generateName: calico-node-vertical-autoscaler-664dc78496-\r\n  labels:\r\n    k8s-app: calico-node-autoscaler\r\n    pod-template-hash: "2208734052"\r\n  name: calico-node-vertical-autoscaler-664dc78496-qnvn5\r\n  namespace: kube-system\r\n  ownerReferences:\r\n  - apiVersion: extensions/v1beta1\r\n    blockOwnerDeletion: true\r\n    controller: true\r\n    kind: ReplicaSet\r\n    name: calico-node-vertical-autoscaler-664dc78496\r\n    uid: 7d82ff8e-7e06-11e8-8e86-42010a9a0138\r\n  resourceVersion: "1691101"\r\n  selfLink: /api/v1/namespaces/kube-system/pods/calico-node-vertical-autoscaler-664dc78496-qnvn5\r\n  uid: 53b407cc-889a-11e8-8e86-42010a9a0138\r\nspec:\r\n  containers:\r\n  - command:\r\n    - /cpvpa\r\n    - --target=daemonset/calico-node\r\n    - --namespace=kube-system\r\n    - --logtostderr=true\r\n    - --poll-period-seconds=30\r\n    - --v=2\r\n    - --config-file=/etc/config/node-autoscaler\r\n    image: gcr.io/google_containers/cpvpa-amd64:v0.6.0\r\n    imagePullPolicy: IfNotPresent\r\n    name: autoscaler\r\n    resources: {}\r\n    terminationMessagePath: /dev/termination-log\r\n    terminationMessagePolicy: File\r\n    volumeMounts:\r\n    - mountPath: /etc/config\r\n      name: config\r\n    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount\r\n      name: calico-cpva-token-kwjj4\r\n      readOnly: true\r\n  dnsPolicy: ClusterFirst\r\n  nodeName: gke-netpol3-default-pool-a06ebdd6-0gq0\r\n  restartPolicy: Always\r\n  schedulerName: default-scheduler\r\n  securityContext: {}\r\n  serviceAccount: calico-cpva\r\n  serviceAccountName: calico-cpva\r\n  terminationGracePeriodSeconds: 30\r\n  tolerations:\r\n  - effect: NoExecute\r\n    key: node.kubernetes.io/not-ready\r\n    operator: Exists\r\n    tolerationSeconds: 300\r\n  - effect: NoExecute\r\n    key: node.kubernetes.io/unreachable\r\n    operator: Exists\r\n    tolerationSeconds: 300\r\n  volumes:\r\n  - configMap:\r\n      defaultMode: 420\r\n      name: calico-node-vertical-autoscaler\r\n    name: config\r\n  - name: calico-cpva-token-kwjj4\r\n    secret:\r\n      defaultMode: 420\r\n      secretName: calico-cpva-token-kwjj4\r\nstatus:\r\n  conditions:\r\n  - lastProbeTime: null\r\n    lastTransitionTime: 2018-07-16T02:19:40Z\r\n    status: "True"\r\n    type: Initialized\r\n  - lastProbeTime: null\r\n    lastTransitionTime: 2018-07-20T00:40:35Z\r\n    status: "True"\r\n    type: Ready\r\n  - lastProbeTime: null\r\n    lastTransitionTime: 2018-07-16T02:19:40Z\r\n    status: "True"\r\n    type: PodScheduled\r\n  containerStatuses:\r\n  - containerID: docker://f32db0abaf32e67604a6fd5b2f60574b98633ef16f0dbf6c01b59f4fac08d758\r\n    image: asia.gcr.io/google_containers/cpvpa-amd64:v0.6.0\r\n    imageID: docker-pullable://asia.gcr.io/google_containers/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869\r\n    lastState: {}\r\n    name: autoscaler\r\n    ready: true\r\n    restartCount: 0\r\n    state:\r\n      running:\r\n        startedAt: 2018-07-20T00:40:32Z\r\n  hostIP: 10.154.0.2\r\n  phase: Running\r\n  podIP: 10.36.52.10\r\n  qosClass: BestEffort\r\n  startTime: 2018-07-16T02:19:40Z\r\n\r\n------WebKitFormBoundaryjh6hXNUDWrzlmi5c\r\nContent-Disposition: form-data; name="filename"\r\n\r\nwebfile\r\n------WebKitFormBoundaryjh6hXNUDWrzlmi5c--\r\n' --compressed
 

--- a/test/asset/form-prefix-file.json
+++ b/test/asset/form-prefix-file.json
@@ -1,0 +1,26 @@
+file={
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "nginx-apparmor",
+    "labels": {
+      "app": "nginx"
+    },
+    "annotations": {
+      "container.apparmor.security.beta.kubernetes.io/nginx": "localhost/k8s-nginx"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nginx",
+        "image": "nginx",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/asset/form-prefix-file.yml
+++ b/test/asset/form-prefix-file.yml
@@ -1,0 +1,14 @@
+file=apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-apparmor
+  labels:
+    app: nginx
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: localhost/k8s-nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/test/asset/form-prefix-not-file.json
+++ b/test/asset/form-prefix-not-file.json
@@ -1,0 +1,26 @@
+not-file={
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "nginx-apparmor",
+    "labels": {
+      "app": "nginx"
+    },
+    "annotations": {
+      "container.apparmor.security.beta.kubernetes.io/nginx": "localhost/k8s-nginx"
+    }
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "nginx",
+        "image": "nginx",
+        "ports": [
+          {
+            "containerPort": 80
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/asset/form-prefix-not-file.yml
+++ b/test/asset/form-prefix-not-file.yml
@@ -1,0 +1,14 @@
+not-file=apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-apparmor
+  labels:
+    app: nginx
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: localhost/k8s-nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
This fix allows for the use of forms and to keep the current non-standard usage of curl avoiding breaking changes.

The current usages of curl in the README and elsewhere provide raw data with a content-type header saying it's form data. This is non-standard behavior and should be fixed in v3 to correctly parse data as is stated in the header.

Because adhering to the content-type header would be a breaking change we have opted for this backwards compatible bug fix for now of stripping the `file=` prefix if it exists.