### PR TITLE
Moved kubesec-logo to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Security risk analysis for Kubernetes resources
 
 <p align="center">
-  <img src="http://casual-hosting.s3.amazonaws.com/kubesec-logo.png">
+  <img src="https://casual-hosting.s3.amazonaws.com/kubesec-logo.png">
 </p>
 
 ## Live demo


### PR DESCRIPTION
Visiting https://kubesec.io gave me the warning "Mixed Content: The page at 'https://kubesec.io/' was loaded over HTTPS, but requested an insecure image 'http://casual-hosting.s3.amazonaws.com/kubesec-logo.png'. This content should also be served over HTTPS."
The logo itself is available via https. Changing the protocol might fix the warning.