### PR TITLE
fix: account for multi doc yaml splitting issues

### DIFF
--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -22,9 +22,11 @@ func (e *ScanFailedValidationError) Error() string {
 }
 
 var debug bool
+var absolutePath bool
 
 func init() {
 	scanCmd.Flags().BoolVar(&debug, "debug", false, "turn on debug logs")
+	scanCmd.Flags().BoolVar(&absolutePath, "absolute-path", false, "use the absolute path for the file name")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -52,6 +54,9 @@ func getInput(args []string) (File, error) {
 	filePath, err := filepath.Abs(fileName)
 	if err != nil {
 		return file, err
+	}
+	if absolutePath {
+		fileName = filePath
 	}
 
 	fileBytes, err := ioutil.ReadFile(filePath)

--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -66,9 +66,11 @@ func getInput(args []string) (File, error) {
 }
 
 var scanCmd = &cobra.Command{
-	Use:     `scan [file]`,
-	Short:   "Scans Kubernetes resource YAML or JSON",
-	Example: `  scan ./deployment.yaml`,
+	Use:   `scan [file]`,
+	Short: "Scans Kubernetes resource YAML or JSON",
+	Example: `  kubesec scan ./deployment.yaml
+  cat file.json | kubesec scan -
+  helm template -f values.yaml ./chart | kubesec scan /dev/stdin`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return fmt.Errorf("file path is required")

--- a/cmd/kubesec/scan.go
+++ b/cmd/kubesec/scan.go
@@ -48,18 +48,18 @@ func getInput(args []string) (File, error) {
 		}
 		return file, nil
 	}
-
-	filename, err := filepath.Abs(args[0])
+	fileName := args[0]
+	filePath, err := filepath.Abs(fileName)
 	if err != nil {
 		return file, err
 	}
 
-	fileBytes, err := ioutil.ReadFile(filename)
+	fileBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return file, err
 	}
 	file = File{
-		fileName:  filename,
+		fileName:  fileName,
 		fileBytes: fileBytes,
 	}
 	return file, nil
@@ -92,7 +92,7 @@ var scanCmd = &cobra.Command{
 			return err
 		}
 
-		reports, err := ruler.NewRuleset(logger).Run(file.fileBytes)
+		reports, err := ruler.NewRuleset(logger).Run(file.fileName, file.fileBytes)
 		if err != nil {
 			return err
 		}

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -258,10 +258,16 @@ func (rs *Ruleset) Run(fileBytes []byte) ([]Report, error) {
 		report := rs.generateReport(fileBytes)
 		reports = append(reports, report)
 	} else {
-		bits := bytes.Split(fileBytes, []byte(detectLineBreak(fileBytes)+"---"+detectLineBreak(fileBytes)))
-		for _, doc := range bits {
+		lineBreak := detectLineBreak(fileBytes)
+		bits := bytes.Split(fileBytes, []byte(lineBreak+"---"+lineBreak))
+		for i, doc := range bits {
 			if len(doc) < 1 {
-				return nil, &InvalidInputError{}
+				if i+1 == len(bits) {
+					return nil, &InvalidInputError{}
+				}
+				rs.logger.Debugf("empty but not at the end")
+				// Account for cases where the split above results in a completely empty doc rather than ---
+				doc = []byte("---")
 			}
 			data, err := yaml.YAMLToJSON(doc)
 			if err != nil {

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -250,12 +250,12 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 	}
 }
 
-func (rs *Ruleset) Run(fileBytes []byte) ([]Report, error) {
+func (rs *Ruleset) Run(fileName string, fileBytes []byte) ([]Report, error) {
 	reports := make([]Report, 0)
 
 	isJSON := json.Valid(fileBytes)
 	if isJSON {
-		report := rs.generateReport(fileBytes)
+		report := rs.generateReport(fileName, fileBytes)
 		reports = append(reports, report)
 	} else {
 		lineBreak := detectLineBreak(fileBytes)
@@ -277,7 +277,7 @@ func (rs *Ruleset) Run(fileBytes []byte) ([]Report, error) {
 			if err != nil {
 				return reports, err
 			}
-			report := rs.generateReport(data)
+			report := rs.generateReport(fileName, data)
 			reports = append(reports, report)
 		}
 	}
@@ -330,7 +330,7 @@ func GenerateInTotoLink(reports []Report, fileBytes []byte) in_toto.Metablock {
 	return linkMb
 }
 
-func (rs *Ruleset) generateReport(json []byte) Report {
+func (rs *Ruleset) generateReport(fileName string, json []byte) Report {
 	report := Report{
 		Object: "Unknown",
 		Score:  0,
@@ -345,7 +345,7 @@ func (rs *Ruleset) generateReport(json []byte) Report {
 
 	// validate resource with kubeval
 	cfg := kubeval.NewDefaultConfig()
-	cfg.FileName = "resource.json"
+	cfg.FileName = fileName
 	cfg.Strict = true
 
 	// try set kubeval schemas to local path

--- a/pkg/ruler/ruleset_test.go
+++ b/pkg/ruler/ruleset_test.go
@@ -1,11 +1,12 @@
 package ruler
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/ghodss/yaml"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"go.uber.org/zap"
-	"strings"
-	"testing"
 )
 
 func TestRuleset_Run(t *testing.T) {
@@ -50,7 +51,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 
 	critical := len(report.Scoring.Critical)
 	if critical < 1 {
@@ -88,7 +89,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "selector is required") {
 		t.Errorf("Got error %v ", report.Message)
@@ -116,7 +117,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 
 	// kubeval should error out with:
 	// spec.replicas: Invalid type. Expected: integer, given: string
@@ -145,7 +146,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "unknown schema") {
 		t.Errorf("Got error %v ", report.Message)
@@ -168,7 +169,7 @@ data:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "not supported") {
 		t.Errorf("Got error %v ", report.Message)
@@ -212,7 +213,7 @@ spec:
 
 	var reports []Report
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport(json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
 	reports = append(reports, report)
 
 	link := GenerateInTotoLink(reports, []byte(data)).Signed.(in_toto.Link)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -119,6 +119,7 @@ func scanHandler(logger *zap.SugaredLogger, keypath string) http.Handler {
 			return
 		}
 
+		const fileName = "API"
 		body, err := retrieveRequestData(r)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
@@ -127,7 +128,7 @@ func scanHandler(logger *zap.SugaredLogger, keypath string) http.Handler {
 		}
 
 		var payload interface{}
-		reports, err := ruler.NewRuleset(logger).Run(body)
+		reports, err := ruler.NewRuleset(logger).Run(fileName, body)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error() + "\n"))

--- a/test/2_regression.bats
+++ b/test/2_regression.bats
@@ -203,7 +203,7 @@ teardown() {
   skip_if_not_remote
 
   run _app "${TEST_DIR}/asset/form-prefix-not-file.yml"
-  assert_output --regexp ".*resource.json: Missing 'apiVersion' key.*"
+  assert_output --regexp ".*API: Missing 'apiVersion' key.*"
   assert_success
 }
 


### PR DESCRIPTION
Resolves #120

Empty and header only yaml docs are now ignored. Still errors if there are no reports

Also corrected the file name passed to kubeval so errors are nicer.
Added a flag for absolute file names too.