### PR TITLE
pin goreleaser and update codeql changed requirements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2.3.3
 
       - name: Launch goreleaser
-        uses: goreleaser/goreleaser-action@master
+        uses: goreleaser/goreleaser-action@2.4.1
         with:
           args: release
         env:

--- a/.github/workflows/security_analysis.yml
+++ b/.github/workflows/security_analysis.yml
@@ -16,17 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.3
-        with:
-          # Must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head of the pull request.
-          # Only include this option if you are running this workflow on pull requests.
-          fetch-depth: 2
-
-      # If this run was triggered by a pull request event then checkout
-      # the head of the pull request instead of the merge commit.
-      # Only include this step if you are running this workflow on pull requests.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1


### PR DESCRIPTION
resolves #132 
Also pins the goreleaser version (so it can be bumped by PR by dependabot)