### PR TITLE
Allow specifying the location of schema files

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,6 +25,7 @@ var debug bool
 var absolutePath bool
 var format string
 var template string
+var schemaDir string
 var outputLocation string
 var exitCode int
 
@@ -32,6 +33,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&debug, "debug", false, "turn on debug logs")
 	scanCmd.Flags().BoolVar(&absolutePath, "absolute-path", false, "use the absolute path for the file name")
 	scanCmd.Flags().StringVarP(&format, "format", "f", "json", "Set output format (json, template)")
+	scanCmd.Flags().StringVarP(&schemaDir, "schema-dir", "s", "", "Sets the directory for the json schemas")
 	scanCmd.Flags().StringVarP(&template, "template", "t", "", "Set output template, it will check for a file or read input as the")
 	scanCmd.Flags().StringVarP(&outputLocation, "output", "o", "", "Set output location")
 	scanCmd.Flags().IntVar(&exitCode, "exit-code", 2, "Set the exit-code to use on failure")
@@ -105,7 +107,7 @@ var scanCmd = &cobra.Command{
 			return err
 		}
 
-		reports, err := ruler.NewRuleset(logger).Run(file.fileName, file.fileBytes)
+		reports, err := ruler.NewRuleset(logger).Run(file.fileName, file.fileBytes, schemaDir)
 		if err != nil {
 			return err
 		}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -33,7 +33,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&debug, "debug", false, "turn on debug logs")
 	scanCmd.Flags().BoolVar(&absolutePath, "absolute-path", false, "use the absolute path for the file name")
 	scanCmd.Flags().StringVarP(&format, "format", "f", "json", "Set output format (json, template)")
-	scanCmd.Flags().StringVarP(&schemaDir, "schema-dir", "schema-dir", "", "Sets the directory for the json schemas")
+	scanCmd.Flags().StringVar(&schemaDir, "schema-dir", "", "Sets the directory for the json schemas")
 	scanCmd.Flags().StringVarP(&template, "template", "t", "", "Set output template, it will check for a file or read input as the")
 	scanCmd.Flags().StringVarP(&outputLocation, "output", "o", "", "Set output location")
 	scanCmd.Flags().IntVar(&exitCode, "exit-code", 2, "Set the exit-code to use on failure")

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -33,7 +33,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&debug, "debug", false, "turn on debug logs")
 	scanCmd.Flags().BoolVar(&absolutePath, "absolute-path", false, "use the absolute path for the file name")
 	scanCmd.Flags().StringVarP(&format, "format", "f", "json", "Set output format (json, template)")
-	scanCmd.Flags().StringVarP(&schemaDir, "schema-dir", "s", "", "Sets the directory for the json schemas")
+	scanCmd.Flags().StringVarP(&schemaDir, "schema-dir", "schema-dir", "", "Sets the directory for the json schemas")
 	scanCmd.Flags().StringVarP(&template, "template", "t", "", "Set output template, it will check for a file or read input as the")
 	scanCmd.Flags().StringVarP(&outputLocation, "output", "o", "", "Set output location")
 	scanCmd.Flags().IntVar(&exitCode, "exit-code", 2, "Set the exit-code to use on failure")

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -274,12 +274,12 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 	}
 }
 
-func (rs *Ruleset) Run(fileName string, fileBytes []byte) ([]Report, error) {
+func (rs *Ruleset) Run(fileName string, fileBytes []byte, schemaDir string) ([]Report, error) {
 	reports := make([]Report, 0)
 
 	isJSON := json.Valid(fileBytes)
 	if isJSON {
-		report := rs.generateReport(fileName, fileBytes)
+		report := rs.generateReport(fileName, fileBytes, schemaDir)
 		reports = append(reports, report)
 	} else {
 		lineBreak := detectLineBreak(fileBytes)
@@ -301,7 +301,7 @@ func (rs *Ruleset) Run(fileName string, fileBytes []byte) ([]Report, error) {
 			if err != nil {
 				return reports, err
 			}
-			report := rs.generateReport(fileName, data)
+			report := rs.generateReport(fileName, data, schemaDir)
 			reports = append(reports, report)
 		}
 	}
@@ -370,7 +370,7 @@ func containsRule(rules []RuleRef, newRule RuleRef) bool {
 	return false
 }
 
-func (rs *Ruleset) generateReport(fileName string, json []byte) Report {
+func (rs *Ruleset) generateReport(fileName string, json []byte, schemaDir string) Report {
 	report := Report{
 		Object:   "Unknown",
 		FileName: fileName,
@@ -390,8 +390,9 @@ func (rs *Ruleset) generateReport(fileName string, json []byte) Report {
 	cfg.FileName = fileName
 	cfg.Strict = true
 
-	// try set kubeval schemas to local path
-	if _, err := os.Stat("/schemas/kubernetes-json-schema/master/master-standalone"); !os.IsNotExist(err) {
+	if schemaDir != "" {
+		cfg.SchemaLocation = "file://" + schemaDir
+	} else if _, err := os.Stat("/schemas/kubernetes-json-schema/master/master-standalone"); !os.IsNotExist(err) {
 		cfg.SchemaLocation = "file:///schemas"
 	}
 

--- a/pkg/ruler/ruleset_test.go
+++ b/pkg/ruler/ruleset_test.go
@@ -9,6 +9,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const schemaDir = ""
+
 func TestRuleset_Run(t *testing.T) {
 	var data = `
 ---
@@ -51,7 +53,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 
 	critical := len(report.Scoring.Critical)
 	if critical < 1 {
@@ -89,7 +91,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "selector is required") {
 		t.Errorf("Got error %v ", report.Message)
@@ -117,7 +119,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 
 	// kubeval should error out with:
 	// spec.replicas: Invalid type. Expected: integer, given: string
@@ -146,7 +148,7 @@ spec:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "unknown schema") {
 		t.Errorf("Got error %v ", report.Message)
@@ -169,7 +171,7 @@ data:
 		t.Fatal(err.Error())
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 
 	if len(report.Message) < 1 || !strings.Contains(report.Message, "not supported") {
 		t.Errorf("Got error %v ", report.Message)
@@ -213,7 +215,7 @@ spec:
 
 	var reports []Report
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json)
+	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
 	reports = append(reports, report)
 
 	link := GenerateInTotoLink(reports, []byte(data)).Signed.(in_toto.Link)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,7 +121,7 @@ func scanHandler(logger *zap.SugaredLogger, keypath string) http.Handler {
 		}
 
 		var payload interface{}
-		reports, err := ruler.NewRuleset(logger).Run(fileName, body)
+		reports, err := ruler.NewRuleset(logger).Run(fileName, body, "")
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error() + "\n"))


### PR DESCRIPTION
With the current implementation the directory in which the schema files may reside is pinned to ("/schemas"). 
However, in some instances  (i.e. read-only file systems of a serverless function), it is not possible to place the schema files directly under the root folder ("/schemas"). Furthermore, always downloading the schemas is also not viable in a restricted environment.