### PR TITLE
feat: Add check for seccomp field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,20 @@ lint-markdown:
 .PHONY: test
 test: ## unit and local acceptance tests
 	@echo "+ $@"
-	make test-unit build test-acceptance
+	make test-unit build download-schema test-acceptance cleanup-schema
+
+SCHEMA_VERSION = v1.20.0
+.PHONY: download-schema
+download-schema: ## unit and local acceptance tests
+	@echo "+ $@"
+	openapi2jsonschema \
+	  -o dist/schemas/kubernetes-json-schema/master-standalone-strict \
+	  --expanded \
+	  --kubernetes \
+	  --stand-alone \
+	  --strict \
+	  https://raw.githubusercontent.com/kubernetes/kubernetes/${SCHEMA_VERSION}/api/openapi-spec/swagger.json
+	deactivate
 
 .PHONY: test-acceptance
 test-acceptance: ## acceptance tests
@@ -108,6 +121,11 @@ test-unit: ## golang unit tests
 test-unit-verbose: ## golang unit tests (verbose)
 	@echo "+ $@"
 	go test -race -v $$(go list ./... | grep -v '/vendor/') -run "$${RUN:-.*}"
+
+.PHONY: cleanup-schema
+cleanup-schema: ## unit and local acceptance tests
+	@echo "+ $@"
+	rm -rf dist/schemas
 
 # ---
 

--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -211,7 +211,7 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 	seccompAnyRule := Rule{
 		Predicate: rules.SeccompAny,
 		ID:        "SeccompAny",
-		Selector:  ".metadata .annotations .\"container.seccomp.security.alpha.kubernetes.io/pod\"",
+		Selector:  ".metadata .annotations .\"container.seccomp.security.alpha.kubernetes.io/pod\" OR .securityContext .seccompProfile .type (1.19+)",
 		Reason:    "Seccomp profiles set minimum privilege and secure against unknown threats",
 		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
 		Points:    1,

--- a/pkg/rules/seccompAny.go
+++ b/pkg/rules/seccompAny.go
@@ -3,22 +3,38 @@ package rules
 import (
 	"bytes"
 	"fmt"
-	"github.com/thedevsaddam/gojsonq/v2"
 	"regexp"
 	"strings"
+
+	"github.com/thedevsaddam/gojsonq/v2"
 )
 
 // TODO(ajm): tighten these matches, they could be "[seccomp..." or " seccomp...", and "unconfined]" or "unconfined "
 // TODO(ajm): space delimiting matches is insufficient as this could be set to `unconfined blah`
 func SeccompAny(json []byte) int {
+
+	spec := getSpecSelector(json)
 	containers := 0
+
+	capDrop := gojsonq.New().Reader(bytes.NewReader(json)).
+		Find(spec + ".securityContext.seccompProfile.type")
+
+	capDropString := fmt.Sprintf("%v", capDrop)
+
+	if capDrop != nil && capDropString != "" {
+		if capDropString != "Unconfined" {
+			containers++
+			return containers
+		}
+	}
+
 	startWordBoundaryRegex := "[\\[ ]"
 	endWordBoundaryRegex := "[\\] ]"
 
-	capDrop := gojsonq.New().Reader(bytes.NewReader(json)).
+	capDrop = gojsonq.New().Reader(bytes.NewReader(json)).
 		From("metadata.annotations").Get()
 
-	capDropString := fmt.Sprintf("%v", capDrop)
+	capDropString = fmt.Sprintf("%v", capDrop)
 
 	if capDrop != nil && strings.Contains(capDropString, "seccomp.security.alpha.kubernetes.io/pod:") {
 		if !strings.Contains(capDropString, "seccomp.security.alpha.kubernetes.io/pod:unconfined") {

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -108,6 +108,11 @@ teardown() {
   assert_lt_zero_points
 }
 
+@test "passes Pod with non-unconfined seccomp field for all containers" {
+  run _app "${TEST_DIR}/asset/versioned/score-0-pod-seccomp-non-unconfined-v1.19.yml"
+  assert_gt_zero_points
+}
+
 @test "passes Pod with non-unconfined seccomp for all containers" {
   run _app "${TEST_DIR}/asset/score-0-pod-seccomp-non-unconfined.yml"
   assert_gt_zero_points

--- a/test/_helper.bash
+++ b/test/_helper.bash
@@ -95,7 +95,7 @@ else
       # remove --json flags
       ARGS=$(echo "${ARGS}" | sed -E 's,--json,,g')
     fi
-    "${BIN_DIR}"/kubesec scan "${ARGS}";
+    "${BIN_DIR}"/kubesec scan --schema-dir "${BIN_DIR}"schemas/kubernetes-json-schema "${ARGS}";
   }
 
   assert_gt_zero_points() {

--- a/test/asset/score-0-daemonset-host-network.yml
+++ b/test/asset/score-0-daemonset-host-network.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      name: example-daemonset
   template:
     spec:
       hostNetwork: true
       containers:
-      - name: example-daemonset
-        image: example-daemonset:latest
+        - name: example-daemonset
+          image: example-daemonset:latest

--- a/test/asset/score-0-daemonset-host-pid.yml
+++ b/test/asset/score-0-daemonset-host-pid.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      name: example-daemonset
   template:
     spec:
       hostPID: true
       containers:
-      - name: example-daemonset
-        image: example-daemonset:latest
+        - name: example-daemonset
+          image: example-daemonset:latest

--- a/test/asset/score-0-daemonset-mount-docker-socket.yml
+++ b/test/asset/score-0-daemonset-mount-docker-socket.yml
@@ -1,23 +1,26 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-daemonset
   labels:
     app: example-daemonset
 spec:
+  selector:
+    matchLabels:
+      name: example-daemonset
   template:
     metadata:
       labels:
         name: example-daemonset
     spec:
       containers:
-      - name: example-daemonset
-        image: example-daemonset:latest
-        volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
+        - name: example-daemonset
+          image: example-daemonset:latest
+          volumeMounts:
+            - mountPath: /host/var/run/docker.sock
+              name: docker-sock
+              readOnly: false
       volumes:
-      - name: docker-sock
-        hostPath:
-         path: /var/run/docker.sock
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock

--- a/test/asset/score-0-daemonset-securitycontext-privileged.yml
+++ b/test/asset/score-0-daemonset-securitycontext-privileged.yml
@@ -1,99 +1,102 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: example-daemonset
   labels:
     app: example-daemonset
 spec:
+  selector:
+    matchLabels:
+      name: example-daemonset
   template:
     metadata:
       labels:
         name: example-daemonset
     spec:
       tolerations:
-      - key: "dedicated"
-        operator: "Exists"
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
+        - key: "dedicated"
+          operator: "Exists"
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
       hostNetwork: true
       hostPID: true
-      serviceAccount: sysdig-agent                     #OPTIONAL - OpenShift service account for OpenShift
+      serviceAccount: sysdig-agent #OPTIONAL - OpenShift service account for OpenShift
       containers:
-      - name: example-daemonset
-        image: example-daemonset:latest
-        imagePullPolicy: Always
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 200m
-            memory: 1G
-          limits:
-            cpu: 400m
-            memory: 3G
-        env:
-        - name: ACCESS_KEY                                  #REQUIRED - replace with your Sysdig Cloud access key
-          value: "SOME VALUE"
-        - name: COLLECTOR_PORT                             #OPTIONAL - on-prem install only
-          value: "6443"
-        - name: TAGS                                       #OPTIONAL
-          value: "SOME VALUE"
-        - name: COLLECTOR                                  #OPTIONAL - on-prem install only
-          value: "SOME VALUE"
-        - name: SECURE                                     #OPTIONAL - on-prem install only
-          value: "true"
-        - name: CHECK_CERTIFICATE                          #OPTIONAL - on-prem install only
-          value: "false"
-        volumeMounts:
-        - mountPath: /dev/shm
-          name: dshm
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
-        - mountPath: /host/dev
-          name: dev-vol
-          readOnly: false
-        - mountPath: /host/proc
-          name: proc-vol
-          readOnly: true
-        - mountPath: /host/boot
-          name: boot-vol
-          readOnly: true
-        - mountPath: /host/lib/modules
-          name: modules-vol
-          readOnly: true
-        - mountPath: /host/usr
-          name: usr-vol
-        - mountPath: /host/etc/ssl
-          name: etc-ssl
-        - name: config
-          mountPath: /opt/draios/etc/dragent.yaml
-          subPath: dragent.yaml
+        - name: example-daemonset
+          image: example-daemonset:latest
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1G
+            limits:
+              cpu: 400m
+              memory: 3G
+          env:
+            - name: ACCESS_KEY #REQUIRED - replace with your Sysdig Cloud access key
+              value: "SOME VALUE"
+            - name: COLLECTOR_PORT #OPTIONAL - on-prem install only
+              value: "6443"
+            - name: TAGS #OPTIONAL
+              value: "SOME VALUE"
+            - name: COLLECTOR #OPTIONAL - on-prem install only
+              value: "SOME VALUE"
+            - name: SECURE #OPTIONAL - on-prem install only
+              value: "true"
+            - name: CHECK_CERTIFICATE #OPTIONAL - on-prem install only
+              value: "false"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /host/var/run/docker.sock
+              name: docker-sock
+              readOnly: false
+            - mountPath: /host/dev
+              name: dev-vol
+              readOnly: false
+            - mountPath: /host/proc
+              name: proc-vol
+              readOnly: true
+            - mountPath: /host/boot
+              name: boot-vol
+              readOnly: true
+            - mountPath: /host/lib/modules
+              name: modules-vol
+              readOnly: true
+            - mountPath: /host/usr
+              name: usr-vol
+            - mountPath: /host/etc/ssl
+              name: etc-ssl
+            - name: config
+              mountPath: /opt/draios/etc/dragent.yaml
+              subPath: dragent.yaml
       volumes:
-      - name: dshm
-        emptyDir:
-          medium: Memory
-      - name: docker-sock
-        hostPath:
-         path: /var/run/docker.sock
-      - name: dev-vol
-        hostPath:
-         path: /dev
-      - name: proc-vol
-        hostPath:
-         path: /proc
-      - name: boot-vol
-        hostPath:
-         path: /boot
-      - name: modules-vol
-        hostPath:
-         path: /lib/modules
-      - name: usr-vol
-        hostPath:
-          path: /usr
-      - name: etc-ssl
-        hostPath:
-          path: /etc/ssl
-      - name: config
-        configMap:
-          name: agent-config
+        - name: dshm
+          emptyDir:
+            medium: Memory
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: dev-vol
+          hostPath:
+            path: /dev
+        - name: proc-vol
+          hostPath:
+            path: /proc
+        - name: boot-vol
+          hostPath:
+            path: /boot
+        - name: modules-vol
+          hostPath:
+            path: /lib/modules
+        - name: usr-vol
+          hostPath:
+            path: /usr
+        - name: etc-ssl
+          hostPath:
+            path: /etc/ssl
+        - name: config
+          configMap:
+            name: agent-config

--- a/test/asset/score-0-daemonset-volume-host-docker-socket.yml
+++ b/test/asset/score-0-daemonset-volume-host-docker-socket.yml
@@ -1,16 +1,19 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      name: example-daemonset
   template:
     spec:
       containers:
-      - name: example-daemonset
-        image: example-daemonset:latest
-        volumeMounts:
-        - mountPath: /host/var/run/docker.sock
-          name: docker-sock
-          readOnly: false
+        - name: example-daemonset
+          image: example-daemonset:latest
+          volumeMounts:
+            - mountPath: /host/var/run/docker.sock
+              name: docker-sock
+              readOnly: false
       volumes:
-      - name: docker-sock
-        hostPath:
-         path: /var/run/docker.sock
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock

--- a/test/asset/score-0-podsecuritypolicy-permissive.yml
+++ b/test/asset/score-0-podsecuritypolicy-permissive.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: permissive
@@ -12,9 +12,9 @@ spec:
   fsGroup:
     rule: RunAsAny
   hostPorts:
-  - min: 8000
-    max: 8080
+    - min: 8000
+      max: 8080
   volumes:
-  - '*'
+    - "*"
   allowedCapabilities:
-  - '*'
+    - "*"

--- a/test/asset/score-0-statefulset-no-sec.yml
+++ b/test/asset/score-0-statefulset-no-sec.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: web
@@ -10,16 +10,16 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
-        ports:
-        - containerPort: 80
-          name: web
-        volumeMounts:
-        - name: www
-          mountPath: /usr/share/nginx/html
+        - name: nginx
+          image: gcr.io/google_containers/nginx-slim:0.8
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
   volumeClaimTemplates:
-  - metadata:
-      name: www
-    spec:
-      storageClassName: my-storage-class
+    - metadata:
+        name: www
+      spec:
+        storageClassName: my-storage-class

--- a/test/asset/score-1-daemonset-default.yml
+++ b/test/asset/score-1-daemonset-default.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
   selector:
@@ -10,25 +10,25 @@ spec:
         name: fluentd-elasticsearch
     spec:
       containers:
-      - name: fluentd-elasticsearch
-        image: gcr.io/google-containers/fluentd-elasticsearch:1.20
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
+        - name: fluentd-elasticsearch
+          image: gcr.io/google-containers/fluentd-elasticsearch:1.20
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/test/asset/score-1-dep-default.yml
+++ b/test/asset/score-1-dep-default.yml
@@ -1,12 +1,23 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
+metadata:
+  name: carts-db
+  labels:
+    name: carts-db
+  namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          runAsNonRoot: true
+        - name: carts-db
+          image: mongo
+          securityContext:
+            runAsNonRoot: true

--- a/test/asset/score-1-dep-empty-security-context.yml
+++ b/test/asset/score-1-dep-empty-security-context.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -17,6 +17,6 @@ spec:
         app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
+        - name: carts-db
+          image: mongo
+          securityContext:

--- a/test/asset/score-1-dep-invalid-security-context.yml
+++ b/test/asset/score-1-dep-invalid-security-context.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,10 +8,16 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          fake: entry
+        - name: carts-db
+          image: mongo
+          securityContext:
+            fake: entry

--- a/test/asset/score-1-dep-resource-limit-cpu.yml
+++ b/test/asset/score-1-dep-resource-limit-cpu.yml
@@ -1,15 +1,26 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
+metadata:
+  name: carts-db
+  labels:
+    name: carts-db
+  namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        resources:
-          limits:
-            cpu: 300m
-          requests:
-            cpu: 300m
+        - name: carts-db
+          image: mongo
+          resources:
+            limits:
+              cpu: 300m
+            requests:
+              cpu: 300m

--- a/test/asset/score-1-dep-resource-limit-memory.yml
+++ b/test/asset/score-1-dep-resource-limit-memory.yml
@@ -1,5 +1,4 @@
----
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,13 +7,19 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        resources:
-          limits:
-            memory: 2000Mi
-          requests:
-            memory: 2000Mi
+        - name: carts-db
+          image: mongo
+          resources:
+            limits:
+              memory: 2000Mi
+            requests:
+              memory: 2000Mi

--- a/test/asset/score-1-dep-ro-root-fs.yml
+++ b/test/asset/score-1-dep-ro-root-fs.yml
@@ -1,12 +1,18 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          readOnlyRootFilesystem: true
+        - name: carts-db
+          image: mongo
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/test/asset/score-1-dep-seccon-run-as-non-root.yml
+++ b/test/asset/score-1-dep-seccon-run-as-non-root.yml
@@ -1,12 +1,23 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
+metadata:
+  name: carts-db
+  labels:
+    name: carts-db
+  namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          runAsNonRoot: true
+        - name: carts-db
+          image: mongo
+          securityContext:
+            runAsNonRoot: true

--- a/test/asset/score-1-dep-seccon-run-as-user-1.yml
+++ b/test/asset/score-1-dep-seccon-run-as-user-1.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,10 +8,16 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          runAsUser: 1
+        - name: carts-db
+          image: mongo
+          securityContext:
+            runAsUser: 1

--- a/test/asset/score-1-dep-seccon-run-as-user-10001.yml
+++ b/test/asset/score-1-dep-seccon-run-as-user-10001.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,10 +8,16 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: carts-db
   template:
+    metadata:
+      labels:
+        app: carts-db
     spec:
       containers:
-      - name: carts-db
-        image: mongo
-        securityContext:
-          runAsUser: 10001
+        - name: carts-db
+          image: mongo
+          securityContext:
+            runAsUser: 10001

--- a/test/asset/score-1-statefulset-default.yml
+++ b/test/asset/score-1-statefulset-default.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: web
@@ -10,22 +10,22 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
-        ports:
-        - containerPort: 80
-          name: web
-        volumeMounts:
-        - name: www
-          mountPath: /usr/share/nginx/html
-        securityContext:
-          readOnlyRootFilesystem: true
+        - name: nginx
+          image: gcr.io/google_containers/nginx-slim:0.8
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
+          securityContext:
+            readOnlyRootFilesystem: true
   volumeClaimTemplates:
-  - metadata:
-      name: www
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: my-storage-class
-      resources:
-        requests:
-          storage: 1Gi
+    - metadata:
+        name: www
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: my-storage-class
+        resources:
+          requests:
+            storage: 1Gi

--- a/test/asset/score-1-statefulset-volumeclaimtemplate.yml
+++ b/test/asset/score-1-statefulset-volumeclaimtemplate.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: web
@@ -10,20 +10,20 @@ spec:
   template:
     spec:
       containers:
-      - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
-        ports:
-        - containerPort: 80
-          name: web
-        volumeMounts:
-        - name: www
-          mountPath: /usr/share/nginx/html
+        - name: nginx
+          image: gcr.io/google_containers/nginx-slim:0.8
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
   volumeClaimTemplates:
-  - metadata:
-      name: www
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: my-storage-class
-      resources:
-        requests:
-          storage: 1Gi
+    - metadata:
+        name: www
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: my-storage-class
+        resources:
+          requests:
+            storage: 1Gi

--- a/test/asset/score-2-dep-serviceaccount.yml
+++ b/test/asset/score-2-dep-serviceaccount.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # Abbreviated, not a full manifest
+apiVersion: apps/v1 # Abbreviated, not a full manifest
 kind: Deployment
 metadata:
   name: prometheus-deployment
@@ -15,7 +15,7 @@ spec:
     spec:
       serviceAccountName: prometheus-sa
       containers:
-      - name: prometheus
-        image: prom/prometheus:v1.8.0
-        command: ["prometheus", "-config.file=/etc/prom/config.yml"]
+        - name: prometheus
+          image: prom/prometheus:v1.8.0
+          command: ["prometheus", "-config.file=/etc/prom/config.yml"]
     # Run this pod using the "prometheus-sa" service account.

--- a/test/asset/versioned/score-0-daemonset-v1.11.yml
+++ b/test/asset/versioned/score-0-daemonset-v1.11.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -18,9 +18,9 @@ spec:
         run: daemonset
     spec:
       containers:
-      - args:
-        - arse
-        image: arse
-        name: daemonset
-        resources: {}
+        - args:
+            - arse
+          image: arse
+          name: daemonset
+          resources: {}
 status: {}

--- a/test/asset/versioned/score-0-pod-seccomp-non-unconfined-v1.19.yml
+++ b/test/asset/versioned/score-0-pod-seccomp-non-unconfined-v1.19.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+spec:
+  containers:
+    - name: trustworthy-container
+      image: sotrustworthy:latest
+      securityContext:
+        # Note that this is ignored if the Kubernetes node is not running version 1.19 or greater.
+        seccompProfile:
+          type: RuntimeDefault

--- a/test/asset/versioned/score-0-statefulset-v1.11.yml
+++ b/test/asset/versioned/score-0-statefulset-v1.11.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -18,9 +18,9 @@ spec:
         run: statefulset
     spec:
       containers:
-      - args:
-        - arse
-        image: arse
-        name: statefulset
-        resources: {}
+        - args:
+            - arse
+          image: arse
+          name: statefulset
+          resources: {}
 status: {}


### PR DESCRIPTION
Kubernetes 1.19 graduated seccomp to GA:
https://v1-19.docs.kubernetes.io/docs/setup/release/notes/#seccomp-graduates-to-general-availability

Currently, Kubernetes supports field and annotation.
The field is deprecated and Kubernetes 1.22 will remove it.

This PR is a suggestion for handling both.

Signed-off-by: Christian Zunker <christian.zunker@codecentric.cloud>