### PR TITLE
Add support for specifying a schema-dir for http server mode

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -14,7 +14,9 @@ func init() {
 	// FIXME: I don't understand why I need a reference to keypath here,
 	// and the cobra docs don't make it exactly clear.
 	var keypath string
+	var schemaDir string
 	httpCmd.Flags().StringVarP(&keypath, "keypath", "k", "", "Path to in-toto link signing key")
+	httpCmd.Flags().StringVarP(&schemaDir, "schema-dir", "s", "", "Sets the directory for the json schemas")
 	rootCmd.AddCommand(httpCmd)
 }
 
@@ -40,7 +42,9 @@ var httpCmd = &cobra.Command{
 
 		keypath := cmd.Flag("keypath").Value.String()
 
-		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath)
+		schemaDir := cmd.Flag("schema-dir").Value.String()
+
+		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath, schemaDir)
 		return nil
 	},
 }


### PR DESCRIPTION
kubesec scan has a --schema-dir option, but kubesec http has no way
to specify a path. The default is
/schemas/kubernetes-json-schema/master/master-standalone, which will
typically not exist locally, and therefore kubesec falls back to trying
to fetch from https://kubernetesjsonschema.dev/, which fails for any
isolated kubesec instance. Borrow scan's --schema-dir implementation
and shoehorn it into http server mode.

Closes: https://github.com/controlplaneio/kubesec/issues/243
Signed-off-by: Hank Leininger <hlein@korelogic.com>