### PR TITLE
fix: ensure json schema location can be configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,27 @@
+FROM golang:1.19 AS downloader
+
+ARG K8S_SCHEMA_VER=master
+
+WORKDIR /schemas
+
+RUN set -x && \
+    if [ "${K8S_SCHEMA_VER}" != "master" ]; then K8S_SCHEMA_VER="v${K8S_SCHEMA_VER}"; fi && \
+    BASE_URL="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master" && \
+    SCHEMA_PATH="${K8S_SCHEMA_VER}-standalone-strict" && \
+    mkdir "${SCHEMA_PATH}" && \
+    cd "${SCHEMA_PATH}" && \
+    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/pod-v1.json" && \
+    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/daemonset-apps-v1.json" && \
+    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/deployment-apps-v1.json" && \
+    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/statefulset-apps-v1.json"
+
 FROM golang:1.19 AS builder
 
 WORKDIR /kubesec
 
-COPY . .
+COPY main.go go.mod go.sum ./
+COPY cmd/ cmd/
+COPY pkg/ pkg/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec .
 
@@ -10,17 +29,23 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o kubesec .
 
 FROM alpine:3.16
 
+ARG K8S_SCHEMA_VER
+ENV K8S_SCHEMA_VER=${K8S_SCHEMA_VER:-}
+ENV SCHEMA_LOCATION=/schemas
+
 RUN addgroup -S kubesec \
   && adduser -S -g kubesec kubesec \
   && apk --no-cache add ca-certificates
 
 WORKDIR /home/kubesec
 
+# This directory must follow the same structure ($SCHEMA_PATH) as the upstream
+# schema location: github.com/yannh/kubernetes-json-schema
+COPY --from=downloader /schemas /schemas
 COPY --from=builder /kubesec/kubesec /bin/kubesec
-COPY --from=stefanprodan/kubernetes-json-schema:latest /schemas/master-standalone /schemas/master-standalone-strict
 COPY ./templates/ /templates
 
-RUN chown -R kubesec:kubesec ./ /schemas
+RUN chown -R kubesec:kubesec ./ /schemas /templates
 
 USER kubesec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,10 @@ RUN set -x && \
     BASE_URL="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master" && \
     SCHEMA_PATH="${K8S_SCHEMA_VER}-standalone-strict" && \
     mkdir "${SCHEMA_PATH}" && \
-    cd "${SCHEMA_PATH}" && \
-    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/pod-v1.json" && \
-    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/daemonset-apps-v1.json" && \
-    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/deployment-apps-v1.json" && \
-    curl -sSL -O "${BASE_URL}/${SCHEMA_PATH}/statefulset-apps-v1.json"
+    curl -sSL --output-dir "${SCHEMA_PATH}" -O "${BASE_URL}/${SCHEMA_PATH}/pod-v1.json" && \
+    curl -sSL --output-dir "${SCHEMA_PATH}" -O "${BASE_URL}/${SCHEMA_PATH}/daemonset-apps-v1.json" && \
+    curl -sSL --output-dir "${SCHEMA_PATH}" -O "${BASE_URL}/${SCHEMA_PATH}/deployment-apps-v1.json" && \
+    curl -sSL --output-dir "${SCHEMA_PATH}" -O "${BASE_URL}/${SCHEMA_PATH}/statefulset-apps-v1.json"
 
 FROM golang:1.19 AS builder
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME := kubesec
 GITHUB_ORG = controlplaneio
 DOCKER_HUB_ORG = controlplane
+K8S_SCHEMA_VER = 1.25.4
 
 ### github.com/controlplaneio/ensure-content.git makefile-header START ###
 ifeq ($(NAME),)
@@ -126,7 +127,7 @@ prune: ## golang dependency prune
 .PHONY: docker-build
 docker-build: ## builds a docker image
 	@echo "+ $@"
-	docker build --tag "${CONTAINER_NAME}" .
+	docker build --tag "${CONTAINER_NAME}" --build-arg "K8S_SCHEMA_VER=${K8S_SCHEMA_VER}" .
 	docker tag "${CONTAINER_NAME}" "${CONTAINER_NAME_LATEST}"
 	@echo "Successfully tagged ${CONTAINER_NAME} as ${CONTAINER_NAME_LATEST}"
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,51 @@ Run the same command in Docker:
 $ docker run -i kubesec/kubesec:v2 scan /dev/stdin < kubesec-test.yaml
 ```
 
+#### Specify custom schema
+
+Kubesec leverages kubeconform (thanks @yannh) to validate the manifests to scan.
+This implies that specifying different schema locations follows the rules as
+described in [the kubeconform README](https://github.com/yannh/kubeconform#overriding-schemas-location).
+
+Here is a quick overview on how this work for scanning a pod manifest:
+
+- I want to use the latest available schema from upstream.
+
+```bash
+kubesec [scan|http]
+```
+
+Schema will be fetched from: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/pod-v1.json
+
+- I want to use a specific schema version from upstream.
+
+```bash
+kubesec [scan|http] --kubernetes-version 1.25.3
+```
+
+Schema will be fetched from: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.25.3-standalone-strict/pod-v1.json
+
+- I want to use a specific schema version in an airgap environment over HTTP.
+
+```bash
+kubesec [scan|http] --kubernetes-version 1.25.3 --schema-location https://host.server
+```
+
+Schema will be fetched from: https://host.server/v1.25.3-standalone-strict/pod-v1.json
+
+- I want to use a specific schema version in an airgap environment with local files:
+
+```bash
+kubesec [scan|http] --kubernetes-version 1.25.3 --schema-location /opt/schemas
+```
+
+Schema will be fetched from: /opt/schemas/v1.25.3-standalone-strict/pod-v1.json
+
+**Note:** in order to limit external network calls and allow usage in airgap
+environments, the `kubesec` image embeds schemas. If you are looking to change
+the schema location, you'll need to change the `K8S_SCHEMA_VER` and `SCHEMA_LOCATION`
+environment variables at runtime.
+
 ## Kubesec HTTP Server
 
 Kubesec includes a bundled HTTP server

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var keypath string
+
 func init() {
-	// FIXME: I don't understand why I need a reference to keypath here,
-	// and the cobra docs don't make it exactly clear.
-	var keypath string
 	httpCmd.Flags().StringVarP(&keypath, "keypath", "k", "", "Path to in-toto link signing key")
+	httpCmd.Flags().StringSliceVar(&schemaLocations, "schema-location", []string{}, "Override schema location search path, local or http (can be specified multiple times)")
 	rootCmd.AddCommand(httpCmd)
 }
 
@@ -36,11 +36,12 @@ var httpCmd = &cobra.Command{
 		}
 
 		stopCh := server.SetupSignalHandler()
-		jsonLogger, _ := NewLogger("info", "json")
+		jsonLogger, err := NewLogger("info", "json")
+		if err != nil {
+			return fmt.Errorf("Unable to create new logger: %w", err)
+		}
 
-		keypath := cmd.Flag("keypath").Value.String()
-
-		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath)
+		server.ListenAndServe(port, time.Minute, jsonLogger, stopCh, keypath, schemaLocations)
 		return nil
 	},
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -28,7 +28,6 @@ var (
 	format          string
 	template        string
 	k8sVersion      string
-	validateSchema  bool
 	schemaLocations = []string{}
 	outputLocation  string
 	exitCode        int

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,7 +25,7 @@ var debug bool
 var absolutePath bool
 var format string
 var template string
-var schemaDir string
+var schemaLocations = []string{}
 var outputLocation string
 var exitCode int
 
@@ -33,7 +33,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&debug, "debug", false, "turn on debug logs")
 	scanCmd.Flags().BoolVar(&absolutePath, "absolute-path", false, "use the absolute path for the file name")
 	scanCmd.Flags().StringVarP(&format, "format", "f", "json", "Set output format (json, template)")
-	scanCmd.Flags().StringVar(&schemaDir, "schema-dir", "", "Sets the directory for the json schemas")
+	scanCmd.Flags().StringSliceVar(&schemaLocations, "schema-location", []string{}, "Override schema location search path, local or http (can be specified multiple times)")
 	scanCmd.Flags().StringVarP(&template, "template", "t", "", "Set output template, it will check for a file or read input as the")
 	scanCmd.Flags().StringVarP(&outputLocation, "output", "o", "", "Set output location")
 	scanCmd.Flags().IntVar(&exitCode, "exit-code", 2, "Set the exit-code to use on failure")
@@ -107,7 +107,7 @@ var scanCmd = &cobra.Command{
 			return err
 		}
 
-		reports, err := ruler.NewRuleset(logger).Run(file.fileName, file.fileBytes, schemaDir)
+		reports, err := ruler.NewRuleset(logger).Run(file.fileName, file.fileBytes, true, schemaLocations)
 		if err != nil {
 			return err
 		}

--- a/pkg/ruler/ruleset_test.go
+++ b/pkg/ruler/ruleset_test.go
@@ -4,15 +4,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"go.uber.org/zap"
 )
 
-const schemaDir = ""
-
-func TestRuleset_Run(t *testing.T) {
-	var data = `
+func TestRulesetRun(t *testing.T) {
+	tests := []struct {
+		name, data string
+	}{
+		{
+			name: "valid yaml",
+			data: `
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -46,32 +48,152 @@ spec:
         - name: c3
           securityContext:
             readOnlyRootFilesystem: true
-`
-
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
-		t.Fatal(err.Error())
+`,
+		},
+		{
+			name: "valid json",
+			data: `
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "podinfo"
+      }
+    },
+    "template": {
+      "metadata": {
+        "annotations": {
+          "prometheus.io/scrape": "true"
+        },
+        "labels": {
+          "app": "podinfo"
+        }
+      },
+      "spec": {
+        "hostNetwork": true,
+        "initContainers": [
+          {
+            "name": "init1",
+            "securityContext": {
+              "readOnlyRootFilesystem": true
+            }
+          },
+          {
+            "name": "init2",
+            "securityContext": {
+              "readOnlyRootFilesystem": false
+            }
+          },
+          {
+            "name": "init3"
+          }
+        ],
+        "containers": [
+          {
+            "name": "c1"
+          },
+          {
+            "name": "c2",
+            "securityContext": {
+              "readOnlyRootFilesystem": false,
+              "runAsNonRoot": true,
+              "runAsUser": 1001
+            }
+          },
+          {
+            "name": "c3",
+            "securityContext": {
+              "readOnlyRootFilesystem": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}`,
+		},
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), true, []string{})
+			if err != nil || len(reports) == 0 {
+				t.Fatal(err.Error())
+			}
 
-	critical := len(report.Scoring.Critical)
-	if critical < 1 {
-		t.Errorf("Got %v critical rules wanted many", critical)
+			report := reports[0]
+
+			critical := len(report.Scoring.Critical)
+			if critical < 1 {
+				t.Errorf("Got %v critical rules wanted many", critical)
+			}
+
+			advise := len(report.Scoring.Advise)
+			if advise < 1 {
+				t.Errorf("Got %v advise rules wanted many", advise)
+			}
+
+			if report.Score > 0 {
+				t.Errorf("Got score %v wanted a negative value", report.Score)
+			}
+
+		})
+	}
+}
+func TestRulesetRunNoSchemaValidation(t *testing.T) {
+	tests := []struct {
+		name, data string
+	}{
+		{
+			name: "missing selectors",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      hostNetwork:
+      containers:
+        - name: c1
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+        - name: c2
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+`,
+		},
 	}
 
-	advise := len(report.Scoring.Advise)
-	if advise < 1 {
-		t.Errorf("Got %v advise rules wanted many", advise)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), false, []string{})
+			if err != nil || len(reports) == 0 {
+				t.Fatal(err.Error())
+			}
 
-	if report.Score > 0 {
-		t.Errorf("Got score %v wanted a negative value", report.Score)
+			report := reports[0]
+
+			if report.Score != 2 {
+				t.Errorf("Got score: %d, expected: 2", report.Score)
+			}
+
+		})
 	}
 }
 
-func TestRuleset_Run_invalid_network(t *testing.T) {
-	var data = `
+func TestRulesetRunInvalid(t *testing.T) {
+	tests := []struct {
+		name, data      string
+		expectedMessage string
+	}{
+		{
+			name: "missing selectors",
+			data: `
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,27 +206,20 @@ spec:
       containers:
         - name: c1
         - name: c2
-`
-
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
-
-	if len(report.Message) < 1 || !strings.Contains(report.Message, "selector is required") {
-		t.Errorf("Got error %v ", report.Message)
-	}
-}
-
-func TestRuleset_Run_invalid_replicas(t *testing.T) {
-	var data = `
+`,
+			expectedMessage: "For field spec: selector is required",
+		},
+		{
+			name: "replicas has wrong type string",
+			data: `
 ---
 apiVersion: apps/v1
 kind: Deployment
 spec:
   replicas: "2"
+  selector:
+    matchLabels:
+      app: podinfo
   template:
     spec:
       initContainers:
@@ -112,24 +227,12 @@ spec:
       containers:
         - name: c1
         - name: c2
-`
-
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
-
-	// kubeval should error out with:
-	// spec.replicas: Invalid type. Expected: integer, given: string
-	if len(report.Message) < 1 || !strings.Contains(report.Message, "Invalid type") {
-		t.Errorf("Got error %v ", report.Message)
-	}
-}
-
-func TestRuleset_Run_invalid_kind(t *testing.T) {
-	var data = `
+`,
+			expectedMessage: "For field spec.replicas: Invalid type",
+		},
+		{
+			name: "resource kind does not exist",
+			data: `
 ---
 apiVersion: apps/v1
 kind: Deployment2
@@ -141,22 +244,12 @@ spec:
       containers:
         - name: c1
         - name: c2
-`
-
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
-
-	if len(report.Message) < 1 || !strings.Contains(report.Message, "could not find schema for Deployment2") {
-		t.Errorf("Got error %v ", report.Message)
-	}
-}
-
-func TestRuleset_Run_not_supported(t *testing.T) {
-	var data = `
+`,
+			expectedMessage: "could not find schema for Deployment2",
+		},
+		{
+			name: "resource kind is not supported (ConfigMap)",
+			data: `
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -164,18 +257,26 @@ metadata:
   name: config
 data:
   color: blue
-`
-
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
-		t.Fatal(err.Error())
+`,
+			expectedMessage: "not supported",
+		},
 	}
 
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), true, []string{})
+			if err != nil || len(reports) == 0 {
+				t.Fatal(err.Error())
+			}
 
-	if len(report.Message) < 1 || !strings.Contains(report.Message, "not supported") {
-		t.Errorf("Got error %v ", report.Message)
+			report := reports[0]
+
+			if report.Message == "" || !strings.Contains(report.Message, tt.expectedMessage) {
+				t.Errorf("Got error %v, expected: %v", report.Message, tt.expectedMessage)
+			}
+		})
 	}
+
 }
 
 func TestRuleset_Get_intoto(t *testing.T) {
@@ -208,15 +309,10 @@ spec:
 
 `
 
-	json, err := yaml.YAMLToJSON([]byte(data))
-	if err != nil {
+	reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(data), true, []string{})
+	if err != nil || len(reports) == 0 {
 		t.Fatal(err.Error())
 	}
-
-	var reports []Report
-
-	report := NewRuleset(zap.NewNop().Sugar()).generateReport("kube.yaml", json, schemaDir)
-	reports = append(reports, report)
 
 	link := GenerateInTotoLink(reports, []byte(data)).Signed.(in_toto.Link)
 

--- a/pkg/ruler/ruleset_test.go
+++ b/pkg/ruler/ruleset_test.go
@@ -118,7 +118,8 @@ spec:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), true, []string{})
+			config := NewDefaultSchemaConfig()
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), config)
 			if err != nil || len(reports) == 0 {
 				t.Fatal(err.Error())
 			}
@@ -171,7 +172,10 @@ spec:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), false, []string{})
+			config := NewDefaultSchemaConfig()
+			config.DisableValidation = true
+
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), config)
 			if err != nil || len(reports) == 0 {
 				t.Fatal(err.Error())
 			}
@@ -264,7 +268,8 @@ data:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), true, []string{})
+			config := NewDefaultSchemaConfig()
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), config)
 			if err != nil || len(reports) == 0 {
 				t.Fatal(err.Error())
 			}
@@ -309,7 +314,8 @@ spec:
 
 `
 
-	reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(data), true, []string{})
+	config := NewDefaultSchemaConfig()
+	reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(data), config)
 	if err != nil || len(reports) == 0 {
 		t.Fatal(err.Error())
 	}

--- a/pkg/ruler/schema.go
+++ b/pkg/ruler/schema.go
@@ -1,0 +1,56 @@
+package ruler
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/yannh/kubeconform/pkg/validator"
+)
+
+// SchemaConfig hold the configuration of the schema validaton.
+type SchemaConfig struct {
+	// DisableValidation disables the validation of the manifests against
+	// Kubernetes JSON schema. Set to true when the source manifests
+	// comes directly from the cluster (e.g: webhook, kubectl plugin).
+	DisableValidation bool
+
+	// Locations defines the locations of the schemas. This follows the
+	// same logic as the -schema-location flag from kubeconform.
+	Locations []string
+
+	// ValidatorOpts are the options from kubeconform validator.
+	ValidatorOpts validator.Opts
+}
+
+func NewDefaultSchemaConfig() SchemaConfig {
+	return SchemaConfig{
+		ValidatorOpts: validator.Opts{
+			Strict: true,
+		},
+	}
+}
+
+// validateSchema validates the json schema of the resource
+// using kubeconform and updates the provided Report.
+func validateSchema(report Report, json []byte, schemaConfig SchemaConfig) Report {
+	v, err := validator.New(schemaConfig.Locations, schemaConfig.ValidatorOpts)
+	if err != nil {
+		report.Message += fmt.Sprintf("failed initializing validator: %s", err)
+		return report
+	}
+
+	f := io.NopCloser(bytes.NewReader(json))
+	for _, res := range v.Validate(report.FileName, f) {
+		// A file might contain multiple resources
+		// File starts with ---, the parser assumes a first empty resource
+		if res.Status == validator.Invalid {
+			report.Message += res.Err.Error() + "\n"
+		}
+		if res.Status == validator.Error {
+			report.Message += res.Err.Error()
+		}
+	}
+
+	return report
+}

--- a/pkg/ruler/schema_test.go
+++ b/pkg/ruler/schema_test.go
@@ -1,0 +1,138 @@
+package ruler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestValidateSchemaHTTP is a quick test to ensure the schemas
+// are fetched from the right location which depends of the GVK and
+// if a Kubernetes version is specified. This does not intend to cover
+// every possible location as this is already tested in kubeconform,
+// just ensuring using SchemaConfig works as expected to pass parameters.
+func TestValidateSchemaHTTP(t *testing.T) {
+	var tests = []struct {
+		name               string
+		data               string
+		kubernetesVersion  string
+		expectedSchemaPath string
+		disableValidation  bool
+	}{
+		{
+			name: "kubernetes version not specified",
+			data: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: test
+        name: test
+`,
+			kubernetesVersion:  "",
+			expectedSchemaPath: "/master-standalone-strict/deployment-apps-v1.json",
+		},
+		{
+			name: "kubernetes version specified",
+			data: `
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: test
+        name: test
+`,
+			kubernetesVersion:  "1.25.4",
+			expectedSchemaPath: "/v1.25.4-standalone-strict/pod-v1.json",
+		},
+		{
+			name: "validation disabled",
+			data: `
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    app: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: test
+        name: test
+`,
+			disableValidation: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			called := false
+			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				if r.URL.Path != tt.expectedSchemaPath {
+					t.Errorf("Path: expected %s, actual %s", tt.expectedSchemaPath, r.URL.Path)
+				}
+			})
+
+			config := NewDefaultSchemaConfig()
+			config.DisableValidation = tt.disableValidation
+			config.Locations = []string{server.URL}
+			config.ValidatorOpts.KubernetesVersion = tt.kubernetesVersion
+
+			reports, err := NewRuleset(zap.NewNop().Sugar()).Run("kube.yaml", []byte(tt.data), config)
+			if err != nil || len(reports) == 0 {
+				t.Fatal(err.Error())
+			}
+
+			if tt.disableValidation && called {
+				t.Error("Validation is disabled but validator tried to fetch a schema")
+			}
+
+			// We don't actually test validation with a proper schema
+			// as this is already done in the ruleset checks.
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,10 +19,18 @@ import (
 )
 
 // ListenAndServe starts a web server and waits for SIGTERM
-func ListenAndServe(port string, timeout time.Duration, logger *zap.SugaredLogger, stopCh <-chan struct{}, keypath string) {
+func ListenAndServe(
+	port string,
+	timeout time.Duration,
+	logger *zap.SugaredLogger,
+	stopCh <-chan struct{},
+	keypath string,
+	schemaLocations []string,
+) {
+
 	mux := http.DefaultServeMux
-	mux.Handle("/", scanHandler(logger, keypath))
-	mux.Handle("/scan", scanHandler(logger, keypath))
+	mux.Handle("/", scanHandler(logger, keypath, schemaLocations))
+	mux.Handle("/scan", scanHandler(logger, keypath, schemaLocations))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -98,7 +106,7 @@ func retrieveRequestData(r *http.Request) ([]byte, error) {
 	return body, nil
 }
 
-func scanHandler(logger *zap.SugaredLogger, keypath string) http.Handler {
+func scanHandler(logger *zap.SugaredLogger, keypath string, schemaLocations []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			http.Redirect(w, r, "https://kubesec.io", http.StatusSeeOther)
@@ -121,7 +129,7 @@ func scanHandler(logger *zap.SugaredLogger, keypath string) http.Handler {
 		}
 
 		var payload interface{}
-		reports, err := ruler.NewRuleset(logger).Run(fileName, body, "")
+		reports, err := ruler.NewRuleset(logger).Run(fileName, body, true, schemaLocations)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error() + "\n"))


### PR DESCRIPTION
Since the migration to kubeconform, the flag `--schema-dir` does not have any effect when provided. This commit replaces it with the flag `--schema-location` that can be used to provide the schema remotely with http or locallly.

This commit also adds an option to disable the schema validation. This will be useful when we will use kubesec as a library for kubectl-kubesec and kubesec-webhook. For these projects, we are getting the object from the cluster so we know the object is properly formated.

Signed-off-by: ludo <controlplane@spiarh.fr>