### PR TITLE
fix: add proc rule

### DIFF
--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -145,6 +145,16 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 	}
 	list = append(list, dockerSockRule)
 
+	procRule := Rule{
+		Predicate: rules.ProcMount,
+		ID:        "ProcMount",
+		Selector:  "volumes[] .hostPath .path == /proc",
+		Reason:    "Mounting the proc directory from the host system into a container gives access to information about other containers running on the same host and can allow container breakout",
+		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
+		Points:    -9,
+	}
+	list = append(list, procRule)
+
 	requestsCPURule := Rule{
 		Predicate: rules.RequestsCPU,
 		ID:        "RequestsCPU",

--- a/pkg/rules/procMount.go
+++ b/pkg/rules/procMount.go
@@ -1,0 +1,24 @@
+package rules
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/thedevsaddam/gojsonq/v2"
+)
+
+func ProcMount(json []byte) int {
+	spec := getSpecSelector(json)
+	found := 0
+
+	paths := gojsonq.New().Reader(bytes.NewReader(json)).
+		From(spec + ".volumes").
+		Only("hostPath.path")
+
+	if paths != nil && strings.Contains(fmt.Sprintf("%v", paths), "/proc") {
+		found++
+	}
+
+	return found
+}

--- a/pkg/rules/procMount_test.go
+++ b/pkg/rules/procMount_test.go
@@ -1,0 +1,111 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func Test_ProcMount_Pod(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+spec:
+  volumes:
+    - name: proc
+      hostPath:
+        path: /proc
+    - name: tmp
+      hostPath:
+        path: /tmp
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := ProcMount(json)
+	if containers != 1 {
+		t.Errorf("Got %v volumes wanted %v", containers, 1)
+	}
+}
+
+func Test_ProcMount_DaemonSet(t *testing.T) {
+	var data = `
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+spec:
+  template:
+    spec:
+      containers:
+      - name: c1
+        volumeMounts:
+        - mountPath: /tmp
+          name: proc
+          readOnly: false
+      volumes:
+      - name: proc
+        hostPath:
+         path: /proc
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := ProcMount(json)
+	if containers != 1 {
+		t.Errorf("Got %v volumes wanted %v", containers, 1)
+	}
+}
+
+func Test_ProcMount_Missing(t *testing.T) {
+	var data = `
+---
+apiVersion: v1
+kind: Pod
+spec:
+  volumes:
+    - name: tmp
+      hostPath:
+        path: /tmp
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := ProcMount(json)
+	if containers != 0 {
+		t.Errorf("Got %v volumes wanted %v", containers, 0)
+	}
+}
+
+func Test_ProcMount_NoVolumes(t *testing.T) {
+	var data = `
+---
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      hostNetwork: false
+      containers:
+        - name: c1
+`
+
+	json, err := yaml.YAMLToJSON([]byte(data))
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	containers := ProcMount(json)
+	if containers != 0 {
+		t.Errorf("Got %v volumes wanted %v", containers, 0)
+	}
+}


### PR DESCRIPTION
Hello, I've noticed that kubesec isn't reacting at mount /proc. This is a potentially big issue for me cause I want to be able to check whether /proc mounted or not

P.S. I'm not a developer feel free to correct my copy-paste code :)