### PR TITLE
Properly inject missing version/date/commit variables

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,6 +20,11 @@ builds:
         goarch: arm
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/controlplaneio/kubesec/v2/cmd.version={{.Version}}
+      - -X github.com/controlplaneio/kubesec/v2/cmd.commit={{.FullCommit}}
+      - -X github.com/controlplaneio/kubesec/v2/cmd.date={{.CommitDate}}
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"


### PR DESCRIPTION
Adding the missing "ldflags" section fixes the following issues:

Fixes https://github.com/controlplaneio/kubesec/issues/250
Fixes https://github.com/controlplaneio/kubesec/issues/337
FYI @06kellyjac 

I've validated this fix locally:

```
$ goreleaser build --snapshot --clean
  • starting build...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • building...                                    commit=5fc3bd266ec4e88f121f3ac168ad88ec9dcd895a latest tag=v0.0.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod tidy
  • snapshotting
    • building snapshot...                           version=v0.0.0-next
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/kubesec_linux_arm_6/kubesec
    • building                                       binary=dist/kubesec_darwin_arm64/kubesec
    • building                                       binary=dist/kubesec_darwin_amd64_v1/kubesec
    • building                                       binary=dist/kubesec_linux_amd64_v1/kubesec
    • building                                       binary=dist/kubesec_linux_arm_7/kubesec
    • building                                       binary=dist/kubesec_linux_arm64/kubesec
^R
    • took: 2s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • build succeeded after 2s
  • thanks for using goreleaser!
$ ./dist/kubesec_linux_amd64_v1/kubesec version
version v0.0.0-next
git commit 5fc3bd266ec4e88f121f3ac168ad88ec9dcd895a
build date 2023-07-03T12:47:42Z
```