### PR TITLE
Add support for multi-arch images

### DIFF
--- a/.github/workflows/release_containers.yml
+++ b/.github/workflows/release_containers.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
         containers:
           - name: kubesec
             file: ./Dockerfile
@@ -73,5 +76,6 @@ jobs:
           file: ${{ matrix.containers.file }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: mode=max,type=local,dest=/tmp/.buildx-cache
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
Fixes https://github.com/controlplaneio/kubesec/issues/448
FYI @06kellyjac 

This should turn all produced images into "multi-arch" images.

Note that if ARM64 images are built on AMD64 machines, an emulator is used, which is several times slower than usual.
However, this should probably be quite fine due to the relatively small size of the image/codebase.

Unfortunately, I have no way to test this right now, so this PR is not validated.