### PR TITLE
chore: stop actions from failing on forks

### DIFF
--- a/.github/workflows/security_analysis.yml
+++ b/.github/workflows/security_analysis.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   codeql:
     name: CodeQL
+    # "Initialize CodeQL" fails on forks and the results would not submit either
+    if: github.repository_owner == 'controlplaneio'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -45,6 +47,8 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy results to the Security tab
+        # can't submit scan results on forks
+        if: github.repository_owner == 'controlplaneio'
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
Some actions need setup or to submit data that only work on the original repo and not on forks

---

Created the PR from a fork rather than in repo as-per-usual to test the changes