### PR TITLE
feat: check automountServiceAccountToken  across K8s resources

### DIFF
--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -10,11 +10,12 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/controlplaneio/kubesec/v2/pkg/rules"
 	"github.com/ghodss/yaml"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/thedevsaddam/gojsonq/v2"
 	"go.uber.org/zap"
+
+	"github.com/controlplaneio/kubesec/v2/pkg/rules"
 )
 
 type Ruleset struct {
@@ -274,6 +275,17 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 		Points:    -7,
 	}
 	list = append(list, allowPrivilegeEscalation)
+
+	automountServiceAccountTokenRule := Rule{
+		Predicate: rules.AutomountServiceAccountToken,
+		ID:        "AutomountServiceAccountToken",
+		Selector:  ".spec .automountServiceAccountToken == false",
+		Reason:    "Disabling the automounting of Service Account Token reduces the attack surface of the API server",
+		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
+		Points:    1,
+	}
+
+	list = append(list, automountServiceAccountTokenRule)
 
 	return &Ruleset{
 		Rules:  list,

--- a/pkg/rules/automountServiceAccountToken.go
+++ b/pkg/rules/automountServiceAccountToken.go
@@ -1,0 +1,22 @@
+package rules
+
+import (
+	"bytes"
+	
+	"github.com/thedevsaddam/gojsonq/v2"
+)
+
+func AutomountServiceAccountToken(json []byte) int {
+	spec := getSpecSelector(json)
+	
+	res := gojsonq.New().Reader(bytes.NewReader(json)).
+		From(spec + ".automountServiceAccountToken").Get()
+	
+	if res != nil {
+		if v, ok := res.(bool); ok && !v {
+			return 1
+		}
+	}
+	
+	return 0
+}

--- a/pkg/rules/automountServiceAccountToken_test.go
+++ b/pkg/rules/automountServiceAccountToken_test.go
@@ -1,0 +1,505 @@
+package rules
+
+import (
+	"testing"
+	
+	"github.com/ghodss/yaml"
+)
+
+func Test_AutomountServiceAccountToken_Pod(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "Pod with automountServiceAccountToken set to false",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  automountServiceAccountToken: false
+  containers:
+  - name: test-container
+    image: test-image:1.14.2
+    ports:
+    - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "Pod with automountServiceAccountToken set to true",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  automountServiceAccountToken: true
+  containers:
+  - name: test-container
+    image: test-image:1.14.2
+    ports:
+    - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Pod with automountServiceAccountToken set to non-boolean value",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  automountServiceAccountToken: nonBooleanValue
+  containers:
+  - name: test-container
+    image: test-image:1.2.3
+    ports:
+    - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+	
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := AutomountServiceAccountToken(json)
+			if got != tc.want {
+				t.Errorf("AutomountServiceAccountToken() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_AutomountServiceAccountToken_Deployment(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "Deployment with automountServiceAccountToken set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "Deployment with automountServiceAccountToken set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment with automountServiceAccountToken not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment with automountServiceAccountToken set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment with automountServiceAccountToken set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+	
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := AutomountServiceAccountToken(json)
+			if got != tc.want {
+				t.Errorf("AutomountServiceAccountToken() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_AutomountServiceAccountToken_Daemonset(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "DaemonSet with automountServiceAccountToken set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "DaemonSet with automountServiceAccountToken set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "DaemonSet with automountServiceAccountToken not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "DaemonSet with automountServiceAccountToken set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      automountServiceAccountToken: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+	
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := AutomountServiceAccountToken(json)
+			if got != tc.want {
+				t.Errorf("AutomountServiceAccountToken() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_AutomountServiceAccountToken_StatefulSet(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "StatefulSet with automountServiceAccountToken set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "StatefulSet with automountServiceAccountToken set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "StatefulSet with automountServiceAccountToken not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "StatefulSet with automountServiceAccountToken set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      automountServiceAccountToken: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+	
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := AutomountServiceAccountToken(json)
+			if got != tc.want {
+				t.Errorf("AutomountServiceAccountToken() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -148,6 +148,11 @@ teardown() {
   assert_lt_zero_points
 }
 
+@test "passes Pod with automountServiceAccountToken set to false" {
+  run _app "${TEST_DIR}/asset/score-1-pod-automount-sa-set-to-false.yml"
+  assert_gt_zero_points
+}
+
 @test "returns integer point score for each advice element" {
   run _app "${TEST_DIR}/asset/score-2-pod-serviceaccount.yml"
   assert_success

--- a/test/asset/score-1-pod-automount-sa-set-to-false.yml
+++ b/test/asset/score-1-pod-automount-sa-set-to-false.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: automount-sa-token-set-to-false
+  namespace: example
+spec:
+  automountServiceAccountToken: false
+  containers:
+    - name: sec-ctx-demo
+      image: gcr.io/google-samples/node-hello:1.0
+      ports:
+      - containerPort: 8080
+        protocol: TCP


### PR DESCRIPTION
- check if automountServiceAccountToken is set/unset in Pods, Deployments, DaemonSets, and StatefulSets
- add unit tests for Pods, Deployments, DaemonSets, and StatefulSets to validate the behavior of the automountServiceAccountToken field