### PR TITLE
feat: check if a Pod is running in user namespace

### DIFF
--- a/pkg/ruler/ruleset.go
+++ b/pkg/ruler/ruleset.go
@@ -298,6 +298,17 @@ func NewRuleset(logger *zap.SugaredLogger) *Ruleset {
 
 	list = append(list, automountServiceAccountTokenRule)
 
+	hostUsersRule := Rule{
+		Predicate: rules.HostUsers,
+		ID:        "HostUsers",
+		Selector:  ".spec .hostUsers == false",
+		Reason:    "A user namespace for a Pod is enabled by setting the hostUsers field of Pod .spec, which can prevent various attacks",
+		Kinds:     []string{"Pod", "Deployment", "StatefulSet", "DaemonSet"},
+		Points:    1,
+	}
+
+	list = append(list, hostUsersRule)
+
 	return &Ruleset{
 		Rules:  list,
 		logger: logger,

--- a/pkg/rules/hostUsers.go
+++ b/pkg/rules/hostUsers.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"bytes"
+
+	"github.com/thedevsaddam/gojsonq/v2"
+)
+
+// HostUsers checks if the hostUsers field is set to false in the container spec.
+// If it is set to false, it returns 1, indicating that the user namespace is being used.
+// Otherwise, it returns 0, indicating that the user namespace is not being used.
+func HostUsers(json []byte) int {
+	spec := getSpecSelector(json)
+
+	res := gojsonq.New().
+		Reader(bytes.NewReader(json)).
+		From(spec + ".hostUsers").Get()
+
+	// hostUsers: false → Kubernetes creates a separate user‑namespace for the pod, giving
+	// the containers their own UID/GID mapping on the node.
+	//
+	// hostUsers: true (or leaving the field out, which defaults to true), the pod shares
+	// the host’s user namespace.
+
+	if res == nil { // if the value is not set, the default is true
+		return 0
+	}
+
+	// If the value is a boolean, we check its value.
+	if v, ok := res.(bool); ok {
+		if !v {
+			return 1
+		}
+		return 0
+	}
+	// default to 0 if the value is not a boolean
+	return 0
+}

--- a/pkg/rules/hostUsers_test.go
+++ b/pkg/rules/hostUsers_test.go
@@ -1,0 +1,505 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func Test_HostUsers_Pod(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "Pod with hostUsers set to false",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  hostUsers: false
+  containers:
+  - name: test-container
+    image: test-image:1.14.2
+    ports:
+    - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "Pod with hostUsers set to true",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  hostUsers: true
+  containers:
+  - name: test-container
+    image: test-image:1.14.2
+    ports:
+    - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Pod with HostUsers set to non-boolean value",
+			data: `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+spec:
+  hostUsers: nonBooleanValue
+  containers:
+  - name: test-container
+    image: test-image:1.2.3
+    ports:
+    - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := HostUsers(json)
+			if got != tc.want {
+				t.Errorf("HostUsers() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_HostUsers_Deployment(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "Deployment with Pod Spec hostUsers set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: false
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "Deployment with Pod Spec hostUsers set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment with Pod Spec hostUsers not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment withPod Spec hostUsers set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "Deployment with hostUsers set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := HostUsers(json)
+			if got != tc.want {
+				t.Errorf("HostUsers() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_HostUsers_Daemonset(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "DaemonSet with Pod Spec. hostUsers set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      hostUsers: false
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "DaemonSet with Pod Spec. hostUsers set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      hostUsers: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "DaemonSet with Pod Spec. hostUsers not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "DaemonSet with Pod Spec. hostUsers set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-app-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: test-app
+  template:
+    metadata:
+      labels:
+        name: test-app
+    spec:
+      hostUsers: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := HostUsers(json)
+			if got != tc.want {
+				t.Errorf("HostUsers() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_HostUsers_StatefulSet(t *testing.T) {
+	testCases := []struct {
+		name string
+		data string
+		want int
+	}{
+		{
+			name: "StatefulSet with Pod Spec. hostUsers set to false",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: false # user namespace for Pod is enabled
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 1,
+		},
+		{
+			name: "StatefulSet with Pod Spec. hostUsers set to true",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: true
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "StatefulSet with Pod spec. hostUsers not set",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+		{
+			name: "StatefulSet with Pod spec hostUsers set to non-boolean value",
+			data: `
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-app-statefulset
+spec:
+  serviceName: "test-app-service"
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      hostUsers: nonBooleanValue
+      containers:
+      - name: test-app
+        image: test-app:1.2.3
+        ports:
+        - containerPort: 80
+`,
+			want: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Convert YAML to JSON
+			json, err := yaml.YAMLToJSON([]byte(tc.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := HostUsers(json)
+			if got != tc.want {
+				t.Errorf("HostUsers() - got %v, wanted %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/1_cli.bats
+++ b/test/1_cli.bats
@@ -188,6 +188,12 @@ teardown() {
   assert_gt_zero_points
 }
 
+@test "passes Pod with hostUsers set to false" {
+  run _app "${TEST_DIR}/asset/score-1-pod-hostUsers-set-to-false.yml"
+  assert_gt_zero_points
+}
+
+
 @test "returns integer point score for each advice element" {
   run _app "${TEST_DIR}/asset/score-2-pod-serviceaccount.yml"
   assert_success

--- a/test/asset/score-1-pod-hostUsers-set-to-false.yml
+++ b/test/asset/score-1-pod-hostUsers-set-to-false.yml
@@ -1,0 +1,16 @@
+---
+# ref https://kubernetes.io/docs/tasks/configure-pod-container/user-namespaces/
+apiVersion: v1
+kind: Pod
+metadata:
+  name: userns
+  namespace: test
+  labels:
+    app: userns
+spec:
+  hostUsers: false
+  containers:
+  - name: shell
+    command: ["sleep", "infinity"]
+    image: debian
+


### PR DESCRIPTION
- In Kubernetes v1.33 support for user namespaces is enabled by default. The new kubesec rule checks if a Pod is running in user namespace instead of host namespace.

<!-- Please skip over these links :) -->
[pull_requests]: https://github.com/controlplaneio/kubesec/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc
[contributing]: https://github.com/controlplaneio/kubesec/blob/master/CONTRIBUTING.md

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**All Submissions.**

- [x] Have you followed the guidelines in our [Contributing document][contributing]?
- [x] Have you checked to ensure there aren't other open [Pull Requests][pull_requests] for the same update/change?

**Code Submissions.**

- [x] Does your submission pass linting, tests, and security analysis?

**Changes to Core Features.**

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
